### PR TITLE
Moving the grant type to be encoded in Access edge tag.

### DIFF
--- a/packages/urns/access.ts
+++ b/packages/urns/access.ts
@@ -3,7 +3,6 @@ import { GrantType } from '@kubelt/types/access'
 
 export type AccessRComp = {
   client_id?: string
-  grant_type?: GrantType
 }
 export type AccessURN = RollupIdURN<`access/${string}`>
 export const AccessURNSpace = createRollupIdURNSpace<

--- a/platform/access/src/constants.ts
+++ b/platform/access/src/constants.ts
@@ -21,4 +21,5 @@ export const JWT_OPTIONS = {
  * An edge linking an account node (representing a user account) and a
  * client session node for that account.
  */
-export const EDGE_ACCESS: EdgeURN = EdgeSpace.urn('owns/access')
+export const EDGE_AUTHENTICATES: EdgeURN = EdgeSpace.urn('authenticates/access')
+export const EDGE_AUTHORIZES: EdgeURN = EdgeSpace.urn('authorizes/access')

--- a/platform/access/src/jsonrpc/methods/exchangeToken.ts
+++ b/platform/access/src/jsonrpc/methods/exchangeToken.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod'
 
-import { EDGE_ACCESS } from '@kubelt/platform.access/src/constants'
+import {
+  EDGE_AUTHENTICATES,
+  EDGE_AUTHORIZES,
+} from '@kubelt/platform.access/src/constants'
 
 import { AccessURNSpace } from '@kubelt/urns/access'
 import { AccountURN } from '@kubelt/urns/account'
@@ -75,18 +78,14 @@ export const exchangeTokenMethod = async ({
 
     // Create an edge between Account and Access nodes to record the
     // existence of a user "session".
-    const access = AccessURNSpace.componentizedUrn(
-      iss,
-      { grant_type: GrantType.AuthenticationCode },
-      undefined
-    )
+    const access = AccessURNSpace.componentizedUrn(iss, undefined)
 
     console.log({ access, edgesClient: ctx.edgesClient })
     // NB: we use InjectEdges middleware to inject this service client.
     await ctx.edgesClient!.makeEdge.mutate({
       src: account,
       dst: access,
-      tag: EDGE_ACCESS,
+      tag: EDGE_AUTHENTICATES,
     })
 
     return result
@@ -139,7 +138,7 @@ export const exchangeTokenMethod = async ({
     // existence of a user "session".
     const access = AccessURNSpace.componentizedUrn(
       iss,
-      { client_id: clientId, grant_type: GrantType.AuthorizationCode },
+      { client_id: clientId },
       undefined
     )
 
@@ -148,7 +147,7 @@ export const exchangeTokenMethod = async ({
     await ctx.edgesClient!.makeEdge.mutate({
       src: account,
       dst: access,
-      tag: EDGE_ACCESS,
+      tag: EDGE_AUTHORIZES,
     })
 
     return result

--- a/platform/access/src/jsonrpc/methods/revokeSession.ts
+++ b/platform/access/src/jsonrpc/methods/revokeSession.ts
@@ -2,7 +2,7 @@
 
 import { z } from 'zod'
 import { AccessURNInput } from '@kubelt/platform-middleware/inputValidators'
-import { EDGE_ACCESS } from '@kubelt/platform.access/src/constants'
+import { EDGE_AUTHENTICATES } from '@kubelt/platform.access/src/constants'
 import { Context } from '../../context'
 
 export const RevokeSessionMethodInput = AccessURNInput
@@ -37,7 +37,8 @@ export const revokeSessionMethod = async ({
     // the context definition.
     src: account!,
     dst: access,
-    tag: EDGE_ACCESS,
+    //TODO: This may need to be changed to EDGE_AUTHORIZES when we implement revoke
+    tag: EDGE_AUTHENTICATES,
   })
 
   return true

--- a/platform/account/src/jsonrpc/methods/getSessions.ts
+++ b/platform/account/src/jsonrpc/methods/getSessions.ts
@@ -1,7 +1,7 @@
 import createEdgesClient from '@kubelt/platform-clients/edges'
 import type { AccessURN } from '@kubelt/urns/access'
 import { Context } from '../../context'
-import { EDGE_ACCESS } from '@kubelt/platform.access/src/constants'
+import { EDGE_AUTHENTICATES } from '@kubelt/platform.access/src/constants'
 import { Graph } from '@kubelt/types'
 import { inputValidators } from '@kubelt/platform-middleware'
 import { z } from 'zod'
@@ -43,7 +43,8 @@ export const getSessionsMethod = async ({
       // We only want edges that start at the provided account node.
       id: input.account,
       // We only want edges that link to Access nodes (sessions).
-      tag: EDGE_ACCESS,
+      //TODO: This may need to be changed to EDGE_AUTHORIZES when we implement revoke
+      tag: EDGE_AUTHENTICATES,
       // Account -> Access edges indicate session ownership.
       dir: Graph.EdgeDirection.Outgoing,
     },


### PR DESCRIPTION
# Description

Replaces the previous implementation where the grant type for an access edge was being encoded as an r-comp of the Access node of the edge. This moves it to the edge tag, where a user either authenticates (`EDGE_AUTHENTICATES`) what's represented in an Access node, or authorizes (`EDGE_AUTHORIZES`) what's represented in an Access node.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Log in with a new account, and go to Profile. This should create both an authentication edge (for Passport) and an authorization edge (for Profile) in the DB. Edge table reflects the grant type in the tag column; rcomp table reflects the client_id for the authorization access edge.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
