### PR TITLE
chore(platform): Update app and account URNs with q-params in edges.

### DIFF
--- a/packages/urns/account.ts
+++ b/packages/urns/account.ts
@@ -1,6 +1,13 @@
 import { createRollupIdURNSpace, RollupIdURN } from './index'
 
+export type AccountQComps = {
+  name?: string
+  picture?: string
+}
+
 export type AccountURN = RollupIdURN<`account/${string}`>
-export const AccountURNSpace = createRollupIdURNSpace<'account', never, never>(
-  'account'
-)
+export const AccountURNSpace = createRollupIdURNSpace<
+  'account',
+  never,
+  AccountQComps
+>('account')

--- a/packages/urns/application.ts
+++ b/packages/urns/application.ts
@@ -1,8 +1,13 @@
 import { createRollupIdURNSpace, RollupIdURN } from './index'
 
+export type ApplicationQComps = {
+  name?: string
+  iconURL?: string
+}
+
 export type ApplicationURN = RollupIdURN<`application/${string}`>
 export const ApplicationURNSpace = createRollupIdURNSpace<
   'application',
   never,
-  never
+  ApplicationQComps
 >('application')

--- a/platform/account/src/jsonrpc/methods/setProfile.ts
+++ b/platform/account/src/jsonrpc/methods/setProfile.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { inputValidators } from '@kubelt/platform-middleware'
 import { Context } from '../../context'
 import { ProfileSchema } from '../validators/profile'
+import { AccountURNSpace } from '@kubelt/urns/account'
 
 export const SetProfileInput = z.object({
   name: inputValidators.AccountURNInput,
@@ -16,5 +17,20 @@ export const setProfileMethod = async ({
   ctx: Context
 }): Promise<void> => {
   await ctx.account?.class.setProfile(input.profile)
+
+  const qcomps = {
+    name: input.profile.displayName,
+    picture: input.profile.pfp?.image,
+  }
+  const enhancedUrn = AccountURNSpace.componentizedUrn(
+    AccountURNSpace.decode(ctx.accountURN!),
+    undefined,
+    qcomps
+  )
+
+  //TODO make this asynchornous so user's don't need to wait
+  //for the second leg of IO to complete
+  const edge = ctx.edges
+  await edge.updateNode.mutate({ urnOfNode: enhancedUrn })
   return
 }

--- a/platform/edges/src/db/update.ts
+++ b/platform/edges/src/db/update.ts
@@ -9,13 +9,12 @@ import * as urns from 'urns'
 import { AnyURN } from '@kubelt/urns'
 
 import type { EdgeTag, EdgeRecord, Graph, NodeRecord } from './types'
-import { qc } from './select'
 
 // node()
 // -----------------------------------------------------------------------------
 
 /**
- * Insert a node; if it is already present, this is a no-op.
+ * Insert a node; if it is already present, this does an upsert.
  *
  * @returns the inserted node
  */

--- a/platform/edges/src/jsonrpc/methods/updateNodeComps.ts
+++ b/platform/edges/src/jsonrpc/methods/updateNodeComps.ts
@@ -1,0 +1,27 @@
+import { AnyURNInput } from '@kubelt/platform-middleware/inputValidators'
+import { z } from 'zod'
+import { Context } from '../../context'
+import * as db from '../../db'
+import * as update from '../../db/update'
+
+export const UpdateNodeCompsMethodInput = z.object({
+  urnOfNode: AnyURNInput,
+})
+export type UpdateNodeCompsParam = z.infer<typeof UpdateNodeCompsMethodInput>
+
+export const UpdateNodeCompsMethodOutput = z.void()
+
+export type UpdateNodeCompsResult = z.infer<typeof UpdateNodeCompsMethodOutput>
+
+export const updateNodeCompsMethod = async ({
+  input,
+  ctx,
+}: {
+  input: UpdateNodeCompsParam
+  ctx: Context
+}): Promise<UpdateNodeCompsResult> => {
+  const nodeUrn = input.urnOfNode
+  if (!nodeUrn) throw new Error('updateNodeCompsParam: No urn provided')
+  const result = await update.node(ctx.graph, nodeUrn)
+  console.debug('updateNodeCompsParam: results ', { result })
+}

--- a/platform/edges/src/jsonrpc/router.ts
+++ b/platform/edges/src/jsonrpc/router.ts
@@ -27,6 +27,11 @@ import {
 import { LogUsage } from '@kubelt/platform-middleware/log'
 
 import { Analytics } from '@kubelt/platform-middleware/analytics'
+import {
+  updateNodeCompsMethod,
+  UpdateNodeCompsMethodInput,
+  UpdateNodeCompsMethodOutput,
+} from './methods/updateNodeComps'
 
 const t = initTRPC.context<Context>().create({
   errorFormatter({ shape, error }) {
@@ -50,6 +55,12 @@ export const appRouter = t.router({
     .input(FindNodeMethodInput)
     .output(FindNodeMethodOutput)
     .query(findNodeMethod),
+  updateNode: t.procedure
+    .use(LogUsage)
+    .use(Analytics)
+    .input(UpdateNodeCompsMethodInput)
+    .output(UpdateNodeCompsMethodOutput)
+    .mutation(updateNodeCompsMethod),
   getEdges: t.procedure
     .use(LogUsage)
     .use(Analytics)

--- a/platform/starbase/src/jsonrpc/methods/createApp.ts
+++ b/platform/starbase/src/jsonrpc/methods/createApp.ts
@@ -28,7 +28,9 @@ export const createApp = async ({
   // rotateSecret method must be called to generate the initial
   // OAuth secret and return it to the caller.
   const clientId = oauth.makeClientId()
-  const appURN = ApplicationURNSpace.urn(clientId)
+  const appURN = ApplicationURNSpace.componentizedUrn(clientId, undefined, {
+    name: input.clientName,
+  })
   if (!ctx.accountURN) throw new Error('No account URN in context')
 
   const appDO = await getApplicationNodeByClientId(clientId, ctx.StarbaseApp)

--- a/platform/starbase/src/jsonrpc/methods/updateApp.ts
+++ b/platform/starbase/src/jsonrpc/methods/updateApp.ts
@@ -16,8 +16,15 @@ export const updateApp = async ({
   input: z.infer<typeof UpdateAppInput>
   ctx: Context
 }): Promise<void> => {
-  const appURN = ApplicationURNSpace.componentizedUrn(input.clientId)
-  if (!ctx.ownAppURNs || !ctx.ownAppURNs.includes(appURN))
+  const appURN = ApplicationURNSpace.componentizedUrn(
+    input.clientId,
+    undefined,
+    { name: input.updates.name, iconURL: input.updates.icon }
+  )
+  if (
+    !ctx.ownAppURNs ||
+    !ctx.ownAppURNs.includes(ApplicationURNSpace.getBaseURN(appURN))
+  )
     throw new Error(
       `Request received for clientId ${input.clientId} which is not owned by provided account.`
     )
@@ -27,4 +34,7 @@ export const updateApp = async ({
     ctx.StarbaseApp
   )
   appDO.class.update(input.updates)
+
+  //TODO: Make this asynchronous so user doesn't have to wait for the second IO hop
+  ctx.edges.updateNode.mutate({ urnOfNode: appURN })
 }

--- a/platform/starbase/src/jsonrpc/ownAppsMiddleware.ts
+++ b/platform/starbase/src/jsonrpc/ownAppsMiddleware.ts
@@ -23,7 +23,7 @@ export const OwnAppsMiddleware: BaseMiddlewareFunction<{
 
   const ownAppURNs = []
   for (const edge of edgeList && edgeList.edges) {
-    const appURN = edge.dst.id as ApplicationURN
+    const appURN = ApplicationURNSpace.getBaseURN(edge.dst.id as ApplicationURN)
     ownAppURNs.push(appURN)
   }
 


### PR DESCRIPTION
# Description

Adds q-comps to Account and ApplicationURNs to store their name and image, respectively. This is now updated in the Edges node representing that URN. Mutation calls in Account and Starbase have been enhanced to call the node-updating method in Edges too.

Edges should now be up to date with name&image info. 

- Closes #1631

## Type of change

- Chore

# How Has This Been Tested?

For account, by settings and resetting name. For application, by creating and then updating apps - their names and icons.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
