### PR TITLE
fix(platform): Throw on attempts to read public props or verify client creds for unpublished apps.

### DIFF
--- a/apps/passport/app/routes/authorize/index.tsx
+++ b/apps/passport/app/routes/authorize/index.tsx
@@ -72,6 +72,11 @@ export const loader: LoaderFunction = async ({ request, context }) => {
       }),
     ])
 
+    if (!appProfile.published)
+      throw new Error(
+        'Could not find a published application with that client ID'
+      )
+
     return json({
       clientId,
       appProfile,

--- a/platform/starbase/src/jsonrpc/methods/checkAppAuth.ts
+++ b/platform/starbase/src/jsonrpc/methods/checkAppAuth.ts
@@ -22,9 +22,11 @@ export const checkAppAuth = async ({
   const { clientId, clientSecret } = input
 
   const appDO = await getApplicationNodeByClientId(clientId, ctx.StarbaseApp)
-
+  const appDetails = await appDO.class.getDetails()
   const hashedSecret = await secret.hash(clientSecret)
-  const secretValidity = await appDO.class.validateClientSecret(hashedSecret)
+  const secretValidity =
+    (appDetails.published || false) &&
+    (await appDO.class.validateClientSecret(hashedSecret))
 
   return {
     valid: secretValidity,

--- a/platform/starbase/src/jsonrpc/methods/getAppPublicProps.ts
+++ b/platform/starbase/src/jsonrpc/methods/getAppPublicProps.ts
@@ -23,14 +23,14 @@ export const getAppPublicProps = async ({
   )
   const appDetails = await appDO.class.getDetails()
 
-  if (appDetails && appDetails.app) {
+  if (appDetails && appDetails.app && appDetails.published) {
     return {
       name: appDetails.app?.name,
       iconURL: appDetails.app?.icon || '',
     }
   } else {
     throw new Error(
-      `Could not return properties of application with client ID: ${input.clientId}`
+      `Could not return properties for a published application with client ID: ${input.clientId}`
     )
   }
 }


### PR DESCRIPTION
# Description

Throws exceptions in cases where an unpublished app is being queried for public props or when a credentials check is happening against it (exchange code and refresh token calls)

- Closes #1626

## Type of change

- Security Fix

# How Has This Been Tested?

- With the Profile app unpublished, attempted to go to Profile from Console.
- With the Profile app unpublished, attempted to display branded login page. 
- Tested with wallet and github login

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
