### PR TITLE
chore(passport): remove Pepe from error pages

### DIFF
--- a/apps/passport/app/root.tsx
+++ b/apps/passport/app/root.tsx
@@ -153,6 +153,7 @@ export function ErrorBoundary({ error }) {
             message="Something went terribly wrong!"
             trace={error?.stack}
             error={error}
+            pepe={false}
           />
         </div>
 

--- a/apps/passport/app/routes/authenticate.tsx
+++ b/apps/passport/app/routes/authenticate.tsx
@@ -54,7 +54,11 @@ export const CatchBoundary: CatchBoundaryComponent = () => {
 
   return (
     <div className="min-h-[100dvh] flex flex-col justify-center">
-      <ErrorPage code={'' + caught.status} message={caught.data.message} />
+      <ErrorPage
+        code={'' + caught.status}
+        message={caught.data.message}
+        pepe={false}
+      />
     </div>
   )
 }

--- a/packages/design-system/src/pages/error/ErrorPage.tsx
+++ b/packages/design-system/src/pages/error/ErrorPage.tsx
@@ -15,23 +15,32 @@ export type ErrorPageProps = {
   error?: {
     message: string
   }
+  pepe?: boolean
 }
 
-export function ErrorPage({ code, message, trace, error }: ErrorPageProps) {
+export function ErrorPage({
+  code,
+  message,
+  trace,
+  error,
+  pepe = true,
+}: ErrorPageProps) {
   const json = error?.message.replace('Unexpected error.: ', '')
 
   return (
     <article className="relative m-4">
-      <section
-        className="absolute top-0 hidden lg:block right-0 xl:right-[10%] 2xl:right-[22%]"
-        style={{
-          zIndex: -1,
-        }}
-      >
-        <article className="w-60">
-          <Pepe />
-        </article>
-      </section>
+      {pepe && (
+        <section
+          className="absolute top-0 hidden lg:block right-0 xl:right-[10%] 2xl:right-[22%]"
+          style={{
+            zIndex: -1,
+          }}
+        >
+          <article className="w-60">
+            <Pepe />
+          </article>
+        </section>
+      )}
 
       <section className="flex flex-col justify-center items-center">
         <Text size="6xl" weight="extrabold" className="text-gray-800 mb-3">
@@ -48,7 +57,7 @@ export function ErrorPage({ code, message, trace, error }: ErrorPageProps) {
           btnType="primary"
           onClick={() =>
             window && document.referrer
-              ? (window.location = document.referrer)
+              ? (window.location.href = document.referrer)
               : history.back()
           }
         >


### PR DESCRIPTION
# Description

- [x] Add pepe param to ErrorPage
- [x] Make pepe param default true
- [x] Set pepe param to false for passport instances of ErrorPage

- Closes #1668 

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security Fix

# How Has This Been Tested?

- Visually in design system
- Functionally by throwing an error on authenticate route
