### PR TITLE
fix(galaxy): double apply urn prefix

### DIFF
--- a/apps/profile/app/routes/nfts/collection.tsx
+++ b/apps/profile/app/routes/nfts/collection.tsx
@@ -19,8 +19,6 @@ export const loader: LoaderFunction = async ({ request }) => {
     throw new Error('Owner required')
   }
 
-  console.log({ owner })
-
   const collection = srcUrl.searchParams.get('collection')
   if (!collection) {
     throw new Error('Collection required')

--- a/apps/profile/app/routes/nfts/collection.tsx
+++ b/apps/profile/app/routes/nfts/collection.tsx
@@ -19,6 +19,8 @@ export const loader: LoaderFunction = async ({ request }) => {
     throw new Error('Owner required')
   }
 
+  console.log({ owner })
+
   const collection = srcUrl.searchParams.get('collection')
   if (!collection) {
     throw new Error('Collection required')

--- a/platform/galaxy/src/schema/resolvers/nfts.ts
+++ b/platform/galaxy/src/schema/resolvers/nfts.ts
@@ -56,7 +56,7 @@ const nftsResolvers: Resolvers = {
       )
       let ownedNfts: any[] = []
 
-      const accountURN = AccountURNSpace.componentizedUrn(owner)
+      const accountURN = owner as AccountURN
 
       const addresses = (
         (await getConnectedAddresses({
@@ -88,6 +88,8 @@ const nftsResolvers: Resolvers = {
           b.contractMetadata?.name ?? ''
         )
       )
+
+      console.log({ ownedNfts })
 
       return {
         ownedNfts,

--- a/platform/galaxy/src/schema/resolvers/nfts.ts
+++ b/platform/galaxy/src/schema/resolvers/nfts.ts
@@ -89,8 +89,6 @@ const nftsResolvers: Resolvers = {
         )
       )
 
-      console.log({ ownedNfts })
-
       return {
         ownedNfts,
       }


### PR DESCRIPTION
# Description

closes #1696

Fixes owner as accountURN to not duplicate urn prefix

 Bug fix (non-breaking change which fixes an issue)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
