### PR TITLE
fix(passport): console params session should not expire

### DIFF
--- a/apps/passport/app/root.tsx
+++ b/apps/passport/app/root.tsx
@@ -37,7 +37,10 @@ import { Loader } from '@kubelt/design-system/src/molecules/loader/Loader'
 import { ErrorPage } from '@kubelt/design-system/src/pages/error/ErrorPage'
 
 import * as gtag from '~/utils/gtags.client'
-import { getConsoleParamsSession } from './session.server'
+import {
+  getConsoleParamsSession,
+  setConsoleParamsSession,
+} from './session.server'
 import { getStarbaseClient } from './platform.server'
 
 export const meta: MetaFunction = () => ({
@@ -69,7 +72,21 @@ export const loader: LoaderFunction = async ({ request, context }) => {
   const parsedParams = consoleParamsSession
     ? await JSON.parse(consoleParamsSession)
     : undefined
-  const clientId = parsedParams?.clientId || undefined
+  let clientId = parsedParams?.clientId || undefined
+
+  // If we have a new clientId incoming
+  // that is different from what we have
+  // stored in cookie
+  if (
+    context.consoleParams.clientId &&
+    context.consoleParams.clientId !== clientId
+  ) {
+    // Update the cookie with new clientId
+    await setConsoleParamsSession(context.consoleParams, context.env)
+
+    // And use the new clientId to query starbase
+    clientId = context.consoleParams.clientId
+  }
 
   let appProps
   if (clientId) {

--- a/apps/passport/app/session.server.ts
+++ b/apps/passport/app/session.server.ts
@@ -84,7 +84,10 @@ export async function logout(request: Request, redirectTo: string, env: Env) {
 
 const getConsoleParamsSessionStorage = (
   env: Env,
-  MAX_AGE = 300 // 5 minutes
+  // https://developer.chrome.com/blog/cookie-max-age-expires/
+  // As of Chrome release M104 (August 2022) cookies can no longer
+  // set an expiration date more than 400 days in the future.
+  MAX_AGE = 34_560_000
 ) => {
   return createCookieSessionStorage({
     cookie: {


### PR DESCRIPTION
# Description

- Added 400 days expiration date for cookie
- If context has new consoleParams that have a different clientId, replaces console props cookie

- Closes #1695 
- Depends on #1692 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1 - Go to Profile App A
2 - Get redirected to Passport
3 - Get Profile App A branding
4 - Wait 6 minutes
5 - Go to Passport app
6 - See Profile App A branding
7 - Go to Profile App A
8 - Log out
9 - Go to Profile App B
10 - Get redirected to Passport
11 - See Profile B branding