### PR TITLE
chore(scripts): generate AppleId client secret

### DIFF
--- a/scripts/generate-appleid-client-secret.js
+++ b/scripts/generate-appleid-client-secret.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const { readFileSync } = require('node:fs')
+const jose = require('jose')
+
+const alg = 'ES256'
+
+const teamId = process.argv[2] || process.env.TEAM_ID
+const clientId = process.argv[3] || process.env.CLIENT_ID
+const keyFile = process.argv[4]
+
+const privateKey = keyFile
+  ? readFileSync(keyFile, 'utf8')
+  : process.env.PRIVATE_KEY
+
+if (!privateKey) {
+  throw new Error('missing private key')
+}
+
+jose.importPKCS8(privateKey, alg).then((privateKey) => {
+  new jose.SignJWT({})
+    .setProtectedHeader({ alg })
+    .setAudience('https://appleid.apple.com')
+    .setExpirationTime('180 days')
+    .setIssuedAt()
+    .setIssuer(teamId)
+    .setSubject(clientId)
+    .sign(privateKey)
+    .then((jwt) => {
+      process.stdout.write(`${jwt}\n`)
+    })
+})


### PR DESCRIPTION
The script can be executed in two forms.

The first form accepts positional options.

```shell
scripts/generate-appleid-secret $TEAM_ID $CLIENT_ID $PRIVATE_KEY_FILE
```

The second is using environment variables.

- TEAM_ID
- CLIENT_ID
- PRIVATE_KEY