### PR TITLE
feat(access): remove exchanged refresh token

### DIFF
--- a/platform/access/src/nodes/access.ts
+++ b/platform/access/src/nodes/access.ts
@@ -156,6 +156,16 @@ export default class Access extends DOProxy {
       aud: [clientId],
       scope,
     } = payload as AccessJWTPayload
+
+    await this.state.storage.transaction(async (txn) => {
+      if (!payload.jti) {
+        throw new Error('missing JTI')
+      }
+      const tokens = (await txn.get<Tokens>('tokens')) || {}
+      delete tokens[payload.jti]
+      await txn.put({ tokens })
+    })
+
     return this.generate(account, clientId, scope)
   }
 


### PR DESCRIPTION
# Description

The refresh token submitted is verified before issuing a new pair of tokens.

The refresh token is removed after verification which ensures the token is
issued by the access object and still exists in the token map.

- Closes #1578

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Manual