### PR TITLE
chore(edges): Implements results metadata object

### DIFF
--- a/platform/edges/src/db/index.ts
+++ b/platform/edges/src/db/index.ts
@@ -23,6 +23,7 @@ import type {
   EdgeDirection,
   EdgeTag,
   EdgeQueryOptions,
+  EdgeQueryResults,
 } from './types'
 
 // Exported Types
@@ -70,7 +71,7 @@ export async function edges(
   g: Graph,
   query: EdgeQuery,
   opt?: EdgeQueryOptions
-): Promise<Edge[]> {
+): Promise<EdgeQueryResults> {
   return select.edges(g, query, opt)
 }
 

--- a/platform/edges/src/db/types.ts
+++ b/platform/edges/src/db/types.ts
@@ -16,6 +16,7 @@ import {
   EdgeQueryInput,
   Edge,
   EdgeQueryOptionsInput,
+  EdgeQueryResultsOutput,
 } from '../jsonrpc/validators/edge'
 import { Node } from '../jsonrpc/validators/node'
 
@@ -25,6 +26,8 @@ import { Node } from '../jsonrpc/validators/node'
 export type EdgeQuery = z.infer<typeof EdgeQueryInput>
 
 export type EdgeQueryOptions = z.infer<typeof EdgeQueryOptionsInput>
+
+export type EdgeQueryResults = z.infer<typeof EdgeQueryResultsOutput>
 
 export type Edge = z.infer<typeof Edge>
 

--- a/platform/edges/src/jsonrpc/methods/getEdges.ts
+++ b/platform/edges/src/jsonrpc/methods/getEdges.ts
@@ -5,17 +5,16 @@ import {
   Edge as EdgeInput,
   EdgeQueryInput,
   EdgeQueryOptionsInput,
+  EdgeQueryResultsOutput,
 } from '../validators/edge'
-import { Edge } from '../../db/types'
+import { Edge, EdgeQueryResults } from '../../db/types'
 
 export const GetEdgesMethodInput = z.object({
   query: EdgeQueryInput,
   opt: EdgeQueryOptionsInput,
 })
 
-export const GetEdgesMethodOutput = z.object({
-  edges: z.array(EdgeInput),
-})
+export const GetEdgesMethodOutput = EdgeQueryResultsOutput
 
 export type GetEdgesParams = z.infer<typeof GetEdgesMethodInput>
 
@@ -25,14 +24,10 @@ export const getEdgesMethod = async ({
 }: {
   input: GetEdgesParams
   ctx: Context
-}): Promise<{
-  edges: Edge[]
-}> => {
+}): Promise<EdgeQueryResults> => {
   // Get the list of the edges selected by the query, modifying the
   // result as per any options.
   const edges = await db.edges(ctx.graph, input.query, input.opt)
 
-  return {
-    edges,
-  }
+  return edges
 }

--- a/platform/edges/src/jsonrpc/validators/edge.ts
+++ b/platform/edges/src/jsonrpc/validators/edge.ts
@@ -28,7 +28,7 @@ export const Edge = z.object({
 export const EdgeQueryResultsOutput = z.object({
   edges: z.array(Edge),
   metadata: z.object({
-    edgesReturned: z.number().or(z.null()),
+    edgesReturned: z.number(),
     limit: z.number().optional(),
     offset: z.number().optional(),
   }),

--- a/platform/edges/src/jsonrpc/validators/edge.ts
+++ b/platform/edges/src/jsonrpc/validators/edge.ts
@@ -24,3 +24,12 @@ export const Edge = z.object({
   tag: EdgeTagInput,
   createdTimestamp: z.string().nullable(),
 })
+
+export const EdgeQueryResultsOutput = z.object({
+  edges: z.array(Edge),
+  metadata: z.object({
+    edgesReturned: z.number().or(z.null()),
+    limit: z.number().optional(),
+    offset: z.number().optional(),
+  }),
+})


### PR DESCRIPTION
# Description

getEdges interface now returns an object containing edges and a metadata object as follows:
```
{ 
  edgesReturned: number,
  limit?: number,
  offset?: number
}
```

- Closes #1744

## Type of change

- Chore

# How Has This Been Tested?

Quick regression pass on functionality that uses edges, through console (authz summary), profile (links and public profile)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
