### PR TITLE
fix(apps): error boundry "go back" button redirects to console

### DIFF
--- a/apps/passport/app/root.tsx
+++ b/apps/passport/app/root.tsx
@@ -202,6 +202,7 @@ export function ErrorBoundary({ error }) {
             trace={error?.stack}
             error={error}
             pepe={false}
+            backBtn={false}
           />
         </div>
 

--- a/apps/passport/app/routes/authenticate.tsx
+++ b/apps/passport/app/routes/authenticate.tsx
@@ -74,6 +74,7 @@ export const CatchBoundary: CatchBoundaryComponent = () => {
         code={'' + caught.status}
         message={caught.data.message}
         pepe={false}
+        backBtn={false}
       />
     </div>
   )

--- a/packages/design-system/src/pages/error/ErrorPage.tsx
+++ b/packages/design-system/src/pages/error/ErrorPage.tsx
@@ -16,6 +16,7 @@ export type ErrorPageProps = {
     message: string
   }
   pepe?: boolean
+  backBtn?: boolean
 }
 
 export function ErrorPage({
@@ -24,6 +25,7 @@ export function ErrorPage({
   trace,
   error,
   pepe = true,
+  backBtn = true,
 }: ErrorPageProps) {
   const json = error?.message.replace('Unexpected error.: ', '')
 
@@ -52,18 +54,23 @@ export function ErrorPage({
       </section>
 
       <section className="flex flex-col justify-center items-center mt-6">
-        <Button
-          btnSize="xxl"
-          btnType="primary"
-          onClick={() =>
-            window && document.referrer
-              ? (window.location.href = document.referrer)
-              : history.back()
-          }
-        >
-          Go back
-        </Button>
-        <Text className="my-3">or</Text>
+        {backBtn && (
+          <>
+            <Button
+              btnSize="xxl"
+              btnType="primary"
+              onClick={() =>
+                window && document.referrer
+                  ? (window.location.href = document.referrer)
+                  : history.back()
+              }
+            >
+              Go back
+            </Button>
+            <Text className="my-3">or</Text>
+          </>
+        )}
+
         <ButtonAnchor
           btnSize="xxl"
           btnType="secondary"


### PR DESCRIPTION
# Description

- Added ErrorPage property to hide "Go Back" button
- Made default visible
- Removed Go Back in passport

- Closes #1700 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Visually by throwing error in Authenticate route & in storybook component
