### PR TITLE
chore(edges): Implemented findNode

### DIFF
--- a/platform/edges/src/db/index.ts
+++ b/platform/edges/src/db/index.ts
@@ -24,6 +24,7 @@ import type {
   EdgeTag,
   EdgeQueryOptions,
   EdgeQueryResults,
+  NodeFilter,
 } from './types'
 import { parseUrnForEdge } from '@kubelt/urns/edge'
 
@@ -57,9 +58,9 @@ export function init(db: D1Database): Graph {
  */
 export async function node(
   g: Graph,
-  nodeId: AnyURN | undefined
+  filter: NodeFilter
 ): Promise<Node | undefined> {
-  return select.node(g, nodeId)
+  return select.node(g, filter)
 }
 
 // edges()

--- a/platform/edges/src/jsonrpc/methods/findNode.ts
+++ b/platform/edges/src/jsonrpc/methods/findNode.ts
@@ -1,18 +1,21 @@
-import { z } from 'zod'
+import { NodeFilterInput } from '@kubelt/platform-middleware/inputValidators'
 import { Context } from '../../context'
+import { Node as NodeSchema } from '../validators/node'
+import * as db from '../../db'
+import { Node, NodeFilter } from '../../db/types'
 
-export const FindNodeMethodInput = z.any()
+export const FindNodeMethodInput = NodeFilterInput
 
-export const FindNodeMethodOutput = z.any()
-
-export type FindNodeParams = z.infer<typeof FindNodeMethodInput>
+export const FindNodeMethodOutput = NodeSchema.optional()
 
 export const findNodeMethod = async ({
   input,
   ctx,
 }: {
-  input: FindNodeParams
+  input: NodeFilter
   ctx: Context
-}): Promise<unknown> => {
-  throw 'findNode Method Not implemented'
+}): Promise<Node | undefined> => {
+  const node = await db.node(ctx.graph, input)
+
+  return node
 }


### PR DESCRIPTION
# Description

Implements the `findNode` method that takes single node parameters and returns a single node, if found. Returns undefined if not found; throws if more than 1 node was found with given criteria. 

- Closes #1757

## Type of change

- Chore

# How Has This Been Tested?

Temporarily added additional statement to codebase to test the findNode path:
- criteria on `baseUrn` alone
- criteria with the comps alone
- criteria with combination of `baseUrn` and comps
- criteria for which there isn't a node in the DB

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
