### PR TITLE
fix(edges): Fixes ordering issue when limits are applied

### DIFF
--- a/platform/edges/src/db/select.ts
+++ b/platform/edges/src/db/select.ts
@@ -174,7 +174,7 @@ export async function edges(
   // )
 
   let sqlFilters = `
-   countor as (select dense_rank() over (order by x.src, x.tag,x.dst) as edge_no,x.* 
+   countor as (select dense_rank() over (order by x.createdTimestamp desc, x.src, x.tag,x.dst) as edge_no,x.* 
    from intersector i left join extender x on i.src=x.src and i.tag=x.tag and i.dst=x.dst)
    
    select (select max(edge_no) from countor) as total_edges, * from countor
@@ -184,8 +184,6 @@ export async function edges(
   let optionsConditions = `where edge_no > ${offset} `
   if (opt?.limit) optionsConditions += `and edge_no <= ${offset + opt.limit} `
   sqlFilters += optionsConditions
-
-  const finalSort = `order by createdTimestamp desc`
 
   enum compType {
     SRCQ = 'SRCQ',
@@ -286,8 +284,7 @@ export async function edges(
     conditionsStatement = `intersector as (${statmentPrefix} ${statementSuffix}), `
   }
 
-  const finalSqlStatement =
-    sqlBase + conditionsStatement + sqlFilters + finalSort
+  const finalSqlStatement = sqlBase + conditionsStatement + sqlFilters
 
   //Keep this .debug until we're confident around the logic
   console.debug('FULL STATEMENT', finalSqlStatement)


### PR DESCRIPTION
# Description

Fixes ordering issue when limits are applied

- Closes #1775

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on top of Emil's PR, by replicating the scenario that led to the issue being reported. In Console, had multiple pages of users and they were ordered in descending order of creation through the whole resultset, and not just the page I was on.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
