### PR TITLE
fix(passport): handle-empty-app-data-in-sign-flow

### DIFF
--- a/apps/passport/app/routes/connect/$address/sign.tsx
+++ b/apps/passport/app/routes/connect/$address/sign.tsx
@@ -82,7 +82,7 @@ export const action: ActionFunction = async ({ request, context, params }) => {
     jwt: await getJWTConditionallyFromSession(request, context.env),
   })
 
-  if (appData.prompt === 'login' && existing) {
+  if (appData?.prompt === 'login' && existing) {
     return redirect(`${appData.redirectUri}?error=ALREADY_CONNECTED`)
   }
 


### PR DESCRIPTION
# Description

Error gets thrown if accessing passport directly. This fixes that.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Did the flow with error then without.