### PR TITLE
chore(passport): mobile view for auth screen update

### DIFF
--- a/apps/passport/app/components/authentication/Authentication.tsx
+++ b/apps/passport/app/components/authentication/Authentication.tsx
@@ -31,14 +31,11 @@ export function Authentication({
   return (
     <div
       className={
-        'flex flex-col items-center justify-center gap-4 basis-96 m-auto bg-white p-6'
+        'flex flex-col items-center justify-center gap-4 mx-auto bg-white p-6 h-[100dvh] lg:h-[598px] w-full lg:w-[418px] lg:border-rounded-lg'
       }
       style={{
-        width: 418,
-        height: 598,
         border: '1px solid #D1D5DB',
         boxSizing: 'border-box',
-        borderRadius: 8,
       }}
     >
       <Avatar src={logo} size="sm"></Avatar>


### PR DESCRIPTION
# Description

Made auth screen take up full mobile view

- Closes #1772 

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Desktop:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/635806/222105553-60aa69f4-1ee7-4207-98c3-e8abcbbfb08d.png">

Galaxy:
<img width="575" alt="image" src="https://user-images.githubusercontent.com/635806/222105787-925f6906-a211-4373-a0e1-faf98eea89a3.png">

Pixel:
<img width="424" alt="image" src="https://user-images.githubusercontent.com/635806/222105923-d758a1ac-7e2d-4344-acd8-4361c70295cb.png">

iPhone:
<img width="477" alt="image" src="https://user-images.githubusercontent.com/635806/222106329-a9fa01ec-6b9d-4706-9c5c-171d52202efb.png">
