### PR TITLE
chore(passport): connect button show who is connected

### DIFF
--- a/apps/passport/app/components/connect-button/ConnectButton.tsx
+++ b/apps/passport/app/components/connect-button/ConnectButton.tsx
@@ -62,8 +62,13 @@ export function ConnectButton({
               >
                 <img src={walletsSvg} />
               </span>
-              {isConnected
-                ? 'Login With Wallet'
+              {isConnected && address
+                ? `Login With ${
+                    ensName ??
+                    `${address.substring(0, 4)} ... ${address.substring(
+                      address.length - 4
+                    )}`
+                  }`
                 : !isConnecting
                 ? 'Connect Wallet'
                 : 'Connecting'}

--- a/apps/passport/app/components/connect-button/ConnectButton.tsx
+++ b/apps/passport/app/components/connect-button/ConnectButton.tsx
@@ -4,6 +4,7 @@ import { Button } from '@kubelt/design-system/src/atoms/buttons/Button'
 import type { ButtonProps } from '@kubelt/design-system/src/atoms/buttons/Button'
 
 import walletsSvg from './wallets.png'
+import { Avatar } from 'connectkit'
 
 const ConnectKitProvider = lazy(() =>
   import('connectkit').then((module) => ({
@@ -32,7 +33,15 @@ export function ConnectButton({
   return (
     <ConnectKitProvider>
       <CustomConnectKitButton>
-        {({ isConnected, isConnecting, show, hide, address, ensName }) => {
+        {({
+          isConnected,
+          isConnecting,
+          show,
+          hide,
+          address,
+          truncatedAddress,
+          ensName,
+        }) => {
           return (
             <Button
               btnType="secondary-alt"
@@ -51,24 +60,28 @@ export function ConnectButton({
                 alignItems: 'center',
               }}
             >
-              <span
-                style={{
-                  backgroundRepeat: 'no-repeat',
-                  backgroundSize: '100%',
-                  height: 20,
-                  width: 20,
-                  margin: '0 7px',
-                }}
-              >
-                <img src={walletsSvg} />
-              </span>
+              {ensName && (
+                <span className="mr-[7px]">
+                  <Avatar size={20} name={ensName} />
+                </span>
+              )}
+
+              {!ensName && (
+                <span
+                  style={{
+                    backgroundRepeat: 'no-repeat',
+                    backgroundSize: '100%',
+                    height: 20,
+                    width: 20,
+                    margin: '0 7px',
+                  }}
+                >
+                  <img src={walletsSvg} />
+                </span>
+              )}
+
               {isConnected && address
-                ? `Login With ${
-                    ensName ??
-                    `${address.substring(0, 4)} ... ${address.substring(
-                      address.length - 4
-                    )}`
-                  }`
+                ? `Login With ${ensName ?? truncatedAddress}`
                 : !isConnecting
                 ? 'Connect Wallet'
                 : 'Connecting'}

--- a/apps/passport/app/components/connect-button/ConnectButton.tsx
+++ b/apps/passport/app/components/connect-button/ConnectButton.tsx
@@ -81,7 +81,7 @@ export function ConnectButton({
               )}
 
               {isConnected && address
-                ? `Login With ${ensName ?? truncatedAddress}`
+                ? `Login with ${ensName ?? truncatedAddress}`
                 : !isConnecting
                 ? 'Connect Wallet'
                 : 'Connecting'}


### PR DESCRIPTION
# Description

Display ensName or address on login button when wallet is connected

- [x] Display connected address
- [x] Display connected ens name
- [x] Display ens avatar

- Closes #1773 

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<img width="380" alt="image" src="https://user-images.githubusercontent.com/635806/222109424-3fe13a49-80de-439f-a3be-3e50d8a195c6.png">

<img width="387" alt="image" src="https://user-images.githubusercontent.com/635806/222109603-0e3802da-d0c1-4d99-b34a-9a2bcbaf1c16.png">

# Caveats

- There's a flicker between address & ensName if ensName exists. I didn't find any way to interact with the connect button in a way that would allow me to resolve this flicker;
- Displaying ens avatar feels like a large involvement vs. gains for now as the connect button component is very unfriendly with modifying state both inside and outside it.
