### PR TITLE
bug(profile): complete profile cta still shows after updating one field

### DIFF
--- a/apps/profile/app/utils/cta.client.ts
+++ b/apps/profile/app/utils/cta.client.ts
@@ -11,13 +11,7 @@ export const determineProfileCompletionStatus = (
   profile: FullProfile
 ): ProfileCompletionStatus => {
   let base = false
-  if (
-    profile.bio &&
-    profile.cover &&
-    profile.job &&
-    profile.location &&
-    profile.website
-  ) {
+  if (profile.bio || profile.job || profile.location || profile.website) {
     base = true
   }
 


### PR DESCRIPTION
# Description

Added OR condition to profile completion. Had to remove cover because currently we have no way of knowing if covered is uploaded by user or auto-generated. This feels like a larger work than worth feature. Up to reviewer if it's OK to cut out profile or if we start the conversation about how we achieve this.

- Closes #1784 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Created new account
2. Profile CTA visible
3. Updated job field
4. Links CTA now visible instead
