### PR TITLE
fix(profile): update access token in the user session data directly

### DIFF
--- a/apps/profile/app/utils/session.server.tsx
+++ b/apps/profile/app/utils/session.server.tsx
@@ -99,16 +99,15 @@ export async function requireJWT(request: Request, headers = new Headers()) {
         throw redirect('/signout')
       }
 
-      const { access_token, refresh_token } = await token.json<{
+      const { access_token } = await token.json<{
         access_token: string
-        refresh_token: string
       }>()
 
+      const { user } = session.data
+      user.accessToken = access_token
+
       // update the session with the new values
-      session.set('user', {
-        accessToken: access_token,
-        refreshToken: refresh_token,
-      })
+      session.set('user', user)
 
       // commit the session and append the Set-Cookie header
       headers.append(


### PR DESCRIPTION
# Description

The user session data was overwritten completely after the refresh token is
exchanged. The refresh token is now permanent so it is not present in the
exchange result. This patch updates the access token stored in the session data
directly.

- Fixes #1824

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Manual