### PR TITLE
feat(profile): redirect to `/signout` if refresh token is missing

### DIFF
--- a/apps/profile/app/utils/session.server.tsx
+++ b/apps/profile/app/utils/session.server.tsx
@@ -79,6 +79,10 @@ export async function requireJWT(request: Request, headers = new Headers()) {
         user: { refreshToken },
       } = session.data
 
+      if (!refreshToken) {
+        throw redirect('/signout')
+      }
+
       // refresh the access token
       const form = new FormData()
       form.append('grant_type', 'refresh_token')


### PR DESCRIPTION
# Description

Terminates the user session and redirects to the passport for login if the
refresh token is missing in the user session data.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Manual