### PR TITLE
bug(profile): rename accounts

### DIFF
--- a/apps/profile/app/routes/account/connections/rename.tsx
+++ b/apps/profile/app/routes/account/connections/rename.tsx
@@ -15,7 +15,7 @@ export const action: ActionFunction = async ({ request, context }) => {
   const galaxyClient = await getGalaxyClient({
     ...generateTraceContextHeaders(context.traceSpan),
   })
-  galaxyClient.updateAddressNickname(
+  await galaxyClient.updateAddressNickname(
     {
       addressURN: id,
       nickname: name,


### PR DESCRIPTION
# Description

Re-added `await` to method call returning Promise

- Closes #1873 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This is the test, as well as the fix.
