### PR TITLE
bug(address): fix MSFT empty picture object

### DIFF
--- a/apps/passport/app/utils/authenticate.server.ts
+++ b/apps/passport/app/utils/authenticate.server.ts
@@ -156,7 +156,7 @@ const provisionProfile = async (
                 res.profile.sub,
               pfp: {
                 //Cached profile image
-                image: res.profile.rollupidImageUrl as string,
+                image: res.profile.picture as string,
               },
             }
           }

--- a/platform/address/src/jsonrpc/methods/getAddressProfile.ts
+++ b/platform/address/src/jsonrpc/methods/getAddressProfile.ts
@@ -123,16 +123,6 @@ export const getAddressProfileMethod = async ({
     case OAuthAddressType.Microsoft: {
       const oAuthNode = new MicrosoftAddress(nodeClient, ctx)
       const profile = await oAuthNode.getProfile()
-      console.debug('MICROSOFT PROFILE  :')
-      console.debug({
-        address: ctx.addressURN,
-        profile,
-        picture: profile.picture,
-      })
-      if (typeof profile.picture !== 'string') {
-        profile.picture =
-          'https://imagedelivery.net/VqQy1abBMHYDZwVsTbsSMw/0df70d41-00b9-4ea2-8ff9-f91f96297700/public'
-      }
       return {
         urn: ctx.addressURN,
         type: OAuthAddressType.Microsoft,

--- a/platform/address/src/jsonrpc/middlewares/initAddressNode.ts
+++ b/platform/address/src/jsonrpc/middlewares/initAddressNode.ts
@@ -27,7 +27,7 @@ export const initAddressNode: BaseMiddlewareFunction<Context> = async ({
     if (!ctx.alias) {
       throw new Error('missing alias')
     }
-    const imageClient = await createImageClient(ctx.Images, {
+    const imageClient = createImageClient(ctx.Images, {
       headers: generateTraceContextHeaders(ctx.traceSpan),
     })
     const gradient = await imageClient.getGradient.mutate({

--- a/platform/address/src/nodes/microsoft.ts
+++ b/platform/address/src/nodes/microsoft.ts
@@ -32,7 +32,7 @@ export default class MicrosoftAddress extends OAuthAddress {
             profile._json.email ||
             profile._json.sub
         }
-        const gradient = this.node.class.getGradient()
+        const gradient = await this.node.class.getGradient()
         picture = profile._json.rollupidImageUrl || gradient
       }
       return {


### PR DESCRIPTION
# Description

There was an unawaited method call that resulted in a promise object not being resolved and thus the picture field not being properly populated. Also given that the picture field is the || between the Microsoft returned potential image and a gradient, it should be used when populating a profile.

- Closes #1843

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Without avatar
### Navbar
<img width="1219" alt="image" src="https://user-images.githubusercontent.com/635806/225304369-8fe92dcc-a6fe-44ac-9546-9414b2ccf9c4.png">

### Dashboard
<img width="486" alt="image" src="https://user-images.githubusercontent.com/635806/225303801-b6fb548d-b3af-4a57-a3f4-1a1b360ea36d.png">

### Accounts
<img width="971" alt="image" src="https://user-images.githubusercontent.com/635806/225303858-19184067-280f-4347-8980-234abea17d8e.png">

### Auth
<img width="443" alt="image" src="https://user-images.githubusercontent.com/635806/225304530-1f41f753-b228-4431-b754-d3041eb0e2f2.png">

## With avatar
### Navbar
<img width="1217" alt="image" src="https://user-images.githubusercontent.com/635806/225305271-aac4bca2-18d4-4df6-b367-09dc72f5fde1.png">

### Dashboard
<img width="485" alt="image" src="https://user-images.githubusercontent.com/635806/225305196-df1c67f7-0c7f-4bb0-8df3-2cca71b0e3ec.png">

### Accounts
<img width="964" alt="image" src="https://user-images.githubusercontent.com/635806/225305333-3a9536a1-e1a8-44c7-b928-faa81e39de02.png">

### Auth
<img width="436" alt="image" src="https://user-images.githubusercontent.com/635806/225305431-ff35370d-4109-4cbb-8ab2-c9e7ebfbfa66.png">