### PR TITLE
feat(platform): Email OTP verification

### DIFF
--- a/apps/passport/app/routes/connect/email/otp.ts
+++ b/apps/passport/app/routes/connect/email/otp.ts
@@ -3,7 +3,7 @@ import { AddressURNSpace } from '@kubelt/urns/address'
 import { generateHashedIDRef } from '@kubelt/urns/idref'
 import { ActionFunction, json, LoaderFunction } from '@remix-run/cloudflare'
 import { getAddressClient } from '~/platform.server'
-import generateRandomString from '@kubelt/utils/generateRandomString'
+import { getJWTConditionallyFromSession } from '~/session.server'
 
 export const loader: LoaderFunction = async ({ request, context }) => {
   const qp = new URL(request.url).searchParams
@@ -51,6 +51,7 @@ export const action: ActionFunction = async ({ request, context }) => {
   const sucessfulVerification = await addressClient.verifyEmailOTP.mutate({
     code: formData.get('code') as string,
     state: formData.get('state') as string,
+    jwt: await getJWTConditionallyFromSession(request, context.env),
   })
 
   return json({ sucessfulVerification })

--- a/apps/passport/app/routes/connect/email/otp.ts
+++ b/apps/passport/app/routes/connect/email/otp.ts
@@ -1,0 +1,62 @@
+import {
+  CryptoAddressType,
+  EmailAddressType,
+  NodeType,
+} from '@kubelt/types/address'
+import { AddressURNSpace } from '@kubelt/urns/address'
+import { generateHashedIDRef } from '@kubelt/urns/idref'
+import { ActionFunction, json, LoaderFunction } from '@remix-run/cloudflare'
+import { getAddressClient } from '~/platform.server'
+
+export const loader: LoaderFunction = async ({ request, context }) => {
+  const qp = new URL(request.url).searchParams
+  const address = qp.get('address')
+  if (!address) throw new Error('No address included in request')
+
+  const state = Math.random().toString(36).substring(7)
+  const addressURN = AddressURNSpace.componentizedUrn(
+    generateHashedIDRef(EmailAddressType.Email, address),
+    { node_type: NodeType.Email, addr_type: EmailAddressType.Email },
+    { alias: address, hidden: 'true' }
+  )
+
+  const addressClient = getAddressClient(
+    addressURN,
+    context.env,
+    context.traceSpan
+  )
+  try {
+    const code = await addressClient.generateEmailOTP.mutate({
+      address,
+      state,
+    })
+    return json({ state })
+  } catch (e) {
+    console.error('Error generating email OTP', e)
+    throw json(`Error generating email OTP: ${e}`, { status: 500 })
+  }
+}
+
+export const action: ActionFunction = async ({ request, context }) => {
+  const formData = await request.formData()
+  const address = formData.get('address') as string
+  if (!address) throw new Error('No address included in request')
+
+  const addressURN = AddressURNSpace.componentizedUrn(
+    generateHashedIDRef(CryptoAddressType.ETH, address),
+    { node_type: NodeType.Crypto, addr_type: CryptoAddressType.ETH },
+    { alias: address }
+  )
+  const addressClient = getAddressClient(
+    addressURN,
+    context.env,
+    context.traceSpan
+  )
+
+  const sucessfulVerification = await addressClient.verifyEmailOTP.mutate({
+    code: formData.get('code') as string,
+    state: formData.get('state') as string,
+  })
+
+  return json({ sucessfulVerification })
+}

--- a/apps/passport/app/routes/connect/email/otp.ts
+++ b/apps/passport/app/routes/connect/email/otp.ts
@@ -43,9 +43,9 @@ export const action: ActionFunction = async ({ request, context }) => {
   if (!address) throw new Error('No address included in request')
 
   const addressURN = AddressURNSpace.componentizedUrn(
-    generateHashedIDRef(CryptoAddressType.ETH, address),
-    { node_type: NodeType.Crypto, addr_type: CryptoAddressType.ETH },
-    { alias: address }
+    generateHashedIDRef(EmailAddressType.Email, address),
+    { node_type: NodeType.Email, addr_type: EmailAddressType.Email },
+    { alias: address, hidden: 'true' }
   )
   const addressClient = getAddressClient(
     addressURN,

--- a/apps/passport/app/routes/connect/email/otp.ts
+++ b/apps/passport/app/routes/connect/email/otp.ts
@@ -1,19 +1,15 @@
-import {
-  CryptoAddressType,
-  EmailAddressType,
-  NodeType,
-} from '@kubelt/types/address'
+import { EmailAddressType, NodeType } from '@kubelt/types/address'
 import { AddressURNSpace } from '@kubelt/urns/address'
 import { generateHashedIDRef } from '@kubelt/urns/idref'
 import { ActionFunction, json, LoaderFunction } from '@remix-run/cloudflare'
 import { getAddressClient } from '~/platform.server'
+import generateRandomString from '@kubelt/utils/generateRandomString'
 
 export const loader: LoaderFunction = async ({ request, context }) => {
   const qp = new URL(request.url).searchParams
   const address = qp.get('address')
   if (!address) throw new Error('No address included in request')
 
-  const state = Math.random().toString(36).substring(7)
   const addressURN = AddressURNSpace.componentizedUrn(
     generateHashedIDRef(EmailAddressType.Email, address),
     { node_type: NodeType.Email, addr_type: EmailAddressType.Email },
@@ -26,9 +22,8 @@ export const loader: LoaderFunction = async ({ request, context }) => {
     context.traceSpan
   )
   try {
-    const code = await addressClient.generateEmailOTP.mutate({
+    const state = await addressClient.generateEmailOTP.mutate({
       address,
-      state,
     })
     return json({ state })
   } catch (e) {

--- a/apps/profile/app/helpers/profile.ts
+++ b/apps/profile/app/helpers/profile.ts
@@ -252,5 +252,13 @@ export const normalizeProfileToConnection = (profile: any) => {
         icon: `https://cdn.discordapp.com/avatars/${profile.discordId}/${profile.avatar}.png`,
         chain: 'Discord',
       }
+    case 'EmailAddressProfile':
+      return {
+        id: profile.urn,
+        address: profile.email,
+        title: profile.name,
+        icon: profile.picture,
+        chain: 'Email',
+      }
   }
 }

--- a/apps/profile/app/routes/account/connections/index.tsx
+++ b/apps/profile/app/routes/account/connections/index.tsx
@@ -50,11 +50,19 @@ const distinctProfiles = (connectedProfiles: any[]) => {
       .map(normalizeProfileToConnection),
   } as AddressListProps
 
+  const emailProfiles = {
+    addresses: connectedProfiles
+      .filter((p) => p?.nodeType === NodeType.Email)
+      .map((p) => ({ urn: p.urn, ...p?.profile }))
+      .map(normalizeProfileToConnection),
+  } as AddressListProps
+
   return {
     addressCount: connectedProfiles.length,
     cryptoProfiles,
     vaultProfiles,
     oAuthProfiles,
+    emailProfiles,
   }
 }
 
@@ -171,8 +179,13 @@ const AccountSettingsConnections = () => {
     connectedProfiles: any[]
   }>()
 
-  const { cryptoProfiles, vaultProfiles, oAuthProfiles, addressCount } =
-    distinctProfiles(connectedProfiles)
+  const {
+    cryptoProfiles,
+    vaultProfiles,
+    oAuthProfiles,
+    emailProfiles,
+    addressCount,
+  } = distinctProfiles(connectedProfiles)
 
   const [renameModalOpen, setRenameModalOpen] = useState(false)
   const [disconnectModalOpen, setDisconnectModalOpen] = useState(false)
@@ -213,6 +226,7 @@ const AccountSettingsConnections = () => {
     const selectedProfile = cryptoProfiles.addresses
       .concat(vaultProfiles.addresses)
       .concat(oAuthProfiles.addresses)
+      .concat(emailProfiles.addresses)
       .find((p: any) => p.id === actionId)
 
     setActionProfile(selectedProfile)
@@ -322,6 +336,15 @@ const AccountSettingsConnections = () => {
               oAuthProfiles.addresses.map((ap) => ({
                 ...ap,
                 onRenameAccount: undefined,
+              }))
+            )
+            .concat(
+              emailProfiles.addresses.map((ap: AddressListItemProps) => ({
+                ...ap,
+                onRenameAccount: (id: string) => {
+                  setActionId(id)
+                  setRenameModalOpen(true)
+                },
               }))
             )
             .map((ap: AddressListItemProps) => ({

--- a/packages/galaxy-client/gql/address.graphql
+++ b/packages/galaxy-client/gql/address.graphql
@@ -52,6 +52,12 @@ query getAddressProfile($addressURN: URN!) {
         discriminator
         avatar
       }
+
+      ... on EmailAddressProfile {
+        name
+        picture
+        email
+      }
     }
   }
 }
@@ -109,6 +115,12 @@ query getAddressProfiles($addressURNList: [URN!]) {
         username
         discriminator
         avatar
+      }
+
+      ... on EmailAddressProfile {
+        name
+        picture
+        email
       }
     }
   }

--- a/packages/galaxy-client/index.ts
+++ b/packages/galaxy-client/index.ts
@@ -24,7 +24,7 @@ export type AddressProfile = {
   urn: Scalars['URN'];
 };
 
-export type AddressProfilesUnion = CryptoAddressProfile | OAuthAppleProfile | OAuthDiscordProfile | OAuthGithubProfile | OAuthGoogleProfile | OAuthMicrosoftProfile | OAuthTwitterProfile;
+export type AddressProfilesUnion = CryptoAddressProfile | EmailAddressProfile | OAuthAppleProfile | OAuthDiscordProfile | OAuthGithubProfile | OAuthGoogleProfile | OAuthMicrosoftProfile | OAuthTwitterProfile;
 
 export type App = {
   __typename?: 'App';
@@ -51,6 +51,14 @@ export type Edge = {
   dst: Node;
   src: Node;
   tag: Scalars['String'];
+};
+
+export type EmailAddressProfile = {
+  __typename?: 'EmailAddressProfile';
+  address: Scalars['String'];
+  email?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  picture: Scalars['String'];
 };
 
 export type Mutation = {
@@ -266,14 +274,14 @@ export type GetAddressProfileQueryVariables = Exact<{
 }>;
 
 
-export type GetAddressProfileQuery = { __typename?: 'Query', addressProfile: { __typename?: 'AddressProfile', type: string, urn: any, profile: { __typename: 'CryptoAddressProfile', address: string, avatar?: string | null, displayName?: string | null } | { __typename: 'OAuthAppleProfile', name?: string | null, picture: string } | { __typename: 'OAuthDiscordProfile', email?: string | null, username?: string | null, discriminator?: string | null, avatar?: string | null, discordId?: string | null } | { __typename: 'OAuthGithubProfile', id?: number | null, name?: string | null, avatar_url: string, html_url?: string | null, followers?: number | null, following?: number | null, login: string, public_gists?: number | null, public_repos?: number | null } | { __typename: 'OAuthGoogleProfile', email?: string | null, name?: string | null, picture: string } | { __typename: 'OAuthMicrosoftProfile', name?: string | null, picture: string, email?: string | null } | { __typename: 'OAuthTwitterProfile', name?: string | null, screen_name: string, profile_image_url_https: string } } };
+export type GetAddressProfileQuery = { __typename?: 'Query', addressProfile: { __typename?: 'AddressProfile', type: string, urn: any, profile: { __typename: 'CryptoAddressProfile', address: string, avatar?: string | null, displayName?: string | null } | { __typename: 'EmailAddressProfile', name?: string | null, picture: string, email?: string | null } | { __typename: 'OAuthAppleProfile', name?: string | null, picture: string } | { __typename: 'OAuthDiscordProfile', email?: string | null, username?: string | null, discriminator?: string | null, avatar?: string | null, discordId?: string | null } | { __typename: 'OAuthGithubProfile', id?: number | null, name?: string | null, avatar_url: string, html_url?: string | null, followers?: number | null, following?: number | null, login: string, public_gists?: number | null, public_repos?: number | null } | { __typename: 'OAuthGoogleProfile', email?: string | null, name?: string | null, picture: string } | { __typename: 'OAuthMicrosoftProfile', name?: string | null, picture: string, email?: string | null } | { __typename: 'OAuthTwitterProfile', name?: string | null, screen_name: string, profile_image_url_https: string } } };
 
 export type GetAddressProfilesQueryVariables = Exact<{
   addressURNList?: InputMaybe<Array<Scalars['URN']> | Scalars['URN']>;
 }>;
 
 
-export type GetAddressProfilesQuery = { __typename?: 'Query', addressProfiles: Array<{ __typename?: 'AddressProfile', type: string, urn: any, profile: { __typename: 'CryptoAddressProfile', address: string, avatar?: string | null, displayName?: string | null } | { __typename: 'OAuthAppleProfile', name?: string | null, picture: string } | { __typename: 'OAuthDiscordProfile', email?: string | null, username?: string | null, discriminator?: string | null, avatar?: string | null, discordId?: string | null } | { __typename: 'OAuthGithubProfile', id?: number | null, name?: string | null, avatar_url: string, html_url?: string | null, followers?: number | null, following?: number | null, login: string, public_gists?: number | null, public_repos?: number | null } | { __typename: 'OAuthGoogleProfile', email?: string | null, name?: string | null, picture: string } | { __typename: 'OAuthMicrosoftProfile', name?: string | null, picture: string, email?: string | null } | { __typename: 'OAuthTwitterProfile', name?: string | null, screen_name: string, profile_image_url_https: string } }> };
+export type GetAddressProfilesQuery = { __typename?: 'Query', addressProfiles: Array<{ __typename?: 'AddressProfile', type: string, urn: any, profile: { __typename: 'CryptoAddressProfile', address: string, avatar?: string | null, displayName?: string | null } | { __typename: 'EmailAddressProfile', name?: string | null, picture: string, email?: string | null } | { __typename: 'OAuthAppleProfile', name?: string | null, picture: string } | { __typename: 'OAuthDiscordProfile', email?: string | null, username?: string | null, discriminator?: string | null, avatar?: string | null, discordId?: string | null } | { __typename: 'OAuthGithubProfile', id?: number | null, name?: string | null, avatar_url: string, html_url?: string | null, followers?: number | null, following?: number | null, login: string, public_gists?: number | null, public_repos?: number | null } | { __typename: 'OAuthGoogleProfile', email?: string | null, name?: string | null, picture: string } | { __typename: 'OAuthMicrosoftProfile', name?: string | null, picture: string, email?: string | null } | { __typename: 'OAuthTwitterProfile', name?: string | null, screen_name: string, profile_image_url_https: string } }> };
 
 export type GetAccountUrnFromAliasQueryVariables = Exact<{
   provider: Scalars['String'];
@@ -402,6 +410,11 @@ export const GetAddressProfileDocument = gql`
         discriminator
         avatar
       }
+      ... on EmailAddressProfile {
+        name
+        picture
+        email
+      }
     }
   }
 }
@@ -454,6 +467,11 @@ export const GetAddressProfilesDocument = gql`
         username
         discriminator
         avatar
+      }
+      ... on EmailAddressProfile {
+        name
+        picture
+        email
       }
     }
   }

--- a/packages/platform-middleware/trace.ts
+++ b/packages/platform-middleware/trace.ts
@@ -1,3 +1,5 @@
+import generateRandomString from '@kubelt/packages/utils/generateRandomString'
+
 type TraceId = string
 type TraceParentId = string
 type TraceParent = `00-${TraceId}-${TraceParentId}-00`
@@ -66,7 +68,7 @@ const getTraceParentForSpan = (span: TraceSpan): TraceParent => {
 }
 
 const createTraceSpan = (traceparent?: TraceParent): TraceSpan => {
-  const newSpanId = generateId(16)
+  const newSpanId = generateRandomString(16)
 
   let result: TraceSpan
   if (traceparent) {
@@ -83,20 +85,7 @@ const createTraceSpan = (traceparent?: TraceParent): TraceSpan => {
   //If there was no traceparent or the values weren't valid, we create a new one
   //with no parentId
   if (!result!) {
-    result = new TraceSpan(generateId(32), newSpanId)
+    result = new TraceSpan(generateRandomString(32), newSpanId)
   }
-  return result
-}
-
-const generateId = (length: number): string => {
-  if (!length || length < 0)
-    throw new Error('Length of ID to be generated has to be a positive number')
-
-  const buffer = new Uint8Array(length / 2)
-  const randomBuffer = crypto.getRandomValues(buffer)
-  const result = Array.from(randomBuffer, (i) =>
-    i.toString(16).padStart(2, '0')
-  ).join('')
-  console.assert(result.length === length)
   return result
 }

--- a/packages/types/address.ts
+++ b/packages/types/address.ts
@@ -3,6 +3,7 @@ export enum NodeType {
   Vault = 'vault',
   Contract = 'contract',
   OAuth = 'oauth',
+  Email = 'email',
   Handle = 'handle',
 }
 
@@ -23,6 +24,10 @@ export enum OAuthAddressType {
   Discord = 'discord',
 }
 
+export enum EmailAddressType {
+  Email = 'email',
+}
+
 export enum HandleAddressType {
   Handle = 'handle',
 }
@@ -32,3 +37,4 @@ export type AddressType =
   | OAuthAddressType
   | ContractAddressType
   | HandleAddressType
+  | EmailAddressType

--- a/packages/utils/generateRandomString.ts
+++ b/packages/utils/generateRandomString.ts
@@ -1,0 +1,14 @@
+export default function generateRandomString(length: number): string {
+  if (!length || length < 0)
+    throw new Error(
+      'Length of string to be generated has to be a positive number'
+    )
+
+  const buffer = new Uint8Array(length / 2)
+  const randomBuffer = crypto.getRandomValues(buffer)
+  const result = Array.from(randomBuffer, (i) =>
+    i.toString(16).padStart(2, '0')
+  ).join('')
+  console.assert(result.length === length)
+  return result
+}

--- a/platform/address/src/constants.ts
+++ b/platform/address/src/constants.ts
@@ -12,6 +12,7 @@ export const NONCE_OPTIONS = {
 export const EMAIL_VERIFICATION_OPTIONS = {
   codeLength: 6,
   //TODO: change this to 300_000 after testing
-  ttlInMs: 5_000, //5min * 60s * 1000ms,
+  ttlInMs: 30_000, //5min * 60s * 1000ms,
+  regenDelayInMs: 10_000, //1min * 60s * 1000ms
 }
 export const EDGE_ADDRESS: EdgeURN = EdgeSpace.urn('owns/address')

--- a/platform/address/src/constants.ts
+++ b/platform/address/src/constants.ts
@@ -9,4 +9,8 @@ export const NONCE_OPTIONS = {
   ttl: 60000,
 }
 
+export const EMAIL_VERIFICATION_OPTIONS = {
+  codeLength: 6,
+  ttlInMs: 300_000, //5min * 60s * 1000ms,
+}
 export const EDGE_ADDRESS: EdgeURN = EdgeSpace.urn('owns/address')

--- a/platform/address/src/constants.ts
+++ b/platform/address/src/constants.ts
@@ -11,8 +11,8 @@ export const NONCE_OPTIONS = {
 
 export const EMAIL_VERIFICATION_OPTIONS = {
   codeLength: 6,
-  //TODO: change this to 300_000 after testing
-  ttlInMs: 30_000, //5min * 60s * 1000ms,
-  regenDelayInMs: 10_000, //1min * 60s * 1000ms
+  stateLength: 12, //Why 12? Why not..
+  ttlInMs: 300_000, //5min * 60s * 1000ms,
+  regenDelayInMs: 60_000, //1min * 60s * 1000ms
 }
 export const EDGE_ADDRESS: EdgeURN = EdgeSpace.urn('owns/address')

--- a/platform/address/src/constants.ts
+++ b/platform/address/src/constants.ts
@@ -11,6 +11,7 @@ export const NONCE_OPTIONS = {
 
 export const EMAIL_VERIFICATION_OPTIONS = {
   codeLength: 6,
-  ttlInMs: 300_000, //5min * 60s * 1000ms,
+  //TODO: change this to 300_000 after testing
+  ttlInMs: 5_000, //5min * 60s * 1000ms,
 }
 export const EDGE_ADDRESS: EdgeURN = EdgeSpace.urn('owns/address')

--- a/platform/address/src/context.ts
+++ b/platform/address/src/context.ts
@@ -4,6 +4,7 @@ import type { FetchCreateContextFnOptions } from '@trpc/server/adapters/fetch'
 import type { Environment } from './types'
 import type { AddressType, NodeType } from '@kubelt/types/address'
 import createEdgesClient from '@kubelt/platform-clients/edges'
+import createEmailClient from '@kubelt/platform-clients/email'
 import { AddressURN } from '@kubelt/urns/address'
 import { ENSRes } from '@kubelt/platform-clients/ens-utils'
 import { AddressNode } from './nodes'
@@ -26,6 +27,7 @@ interface CreateInnerContextOptions
   ServiceDeploymentMetadata: DeploymentMetadata
   HANDLES: KVNamespace
   Edges: Fetcher
+  Email: Fetcher
   Access: Fetcher
   Images: Fetcher
   address?: AddressNode
@@ -70,10 +72,15 @@ export async function createContextInner(opts: CreateInnerContextOptions) {
     opts.Edges,
     generateTraceContextHeaders(traceSpan)
   )
+  const emailClient = createEmailClient(
+    opts.Email,
+    generateTraceContextHeaders(traceSpan)
+  )
   return {
     ...opts,
     traceSpan,
     edges,
+    emailClient,
   }
 }
 /**

--- a/platform/address/src/jsonrpc/methods/generateEmailOTP.ts
+++ b/platform/address/src/jsonrpc/methods/generateEmailOTP.ts
@@ -1,5 +1,6 @@
 import generateRandomString from '@kubelt/utils/generateRandomString'
 import { z } from 'zod'
+import { EMAIL_VERIFICATION_OPTIONS } from '../../constants'
 import { Context } from '../../context'
 import { AddressNode } from '../../nodes'
 import EmailAddress from '../../nodes/email'
@@ -22,7 +23,7 @@ export const generateEmailOTPMethod = async ({
   const { address } = input
   const emailAddressNode = new EmailAddress(ctx.address as AddressNode)
 
-  const state = generateRandomString(12)
+  const state = generateRandomString(EMAIL_VERIFICATION_OPTIONS.stateLength)
   const code = await emailAddressNode.generateVerificationCode(state)
   await ctx.emailClient.sendEmailNotification.mutate({
     emailAddress: address,

--- a/platform/address/src/jsonrpc/methods/generateEmailOTP.ts
+++ b/platform/address/src/jsonrpc/methods/generateEmailOTP.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+import { Context } from '../../context'
+import { AddressNode } from '../../nodes'
+import EmailAddress from '../../nodes/email'
+
+export const GenerateEmailOTPInput = z.object({
+  address: z.string(),
+  state: z.string(),
+})
+
+export const GenerateEmailOTPOutput = z.string()
+
+type GenerateEmailOTPParams = z.infer<typeof GenerateEmailOTPInput>
+
+export const generateEmailOTPMethod = async ({
+  input,
+  ctx,
+}: {
+  input: GenerateEmailOTPParams
+  ctx: Context
+}): Promise<string> => {
+  const { address, state } = input
+  const emailAddressNode = new EmailAddress(ctx.address as AddressNode)
+
+  const code = await emailAddressNode.generateVerificationCode(state)
+  await ctx.emailClient.sendEmailNotification.mutate({
+    emailAddress: address,
+    name: address,
+    otpCode: code,
+  })
+  return state
+}

--- a/platform/address/src/jsonrpc/methods/generateEmailOTP.ts
+++ b/platform/address/src/jsonrpc/methods/generateEmailOTP.ts
@@ -1,3 +1,4 @@
+import generateRandomString from '@kubelt/utils/generateRandomString'
 import { z } from 'zod'
 import { Context } from '../../context'
 import { AddressNode } from '../../nodes'
@@ -5,7 +6,6 @@ import EmailAddress from '../../nodes/email'
 
 export const GenerateEmailOTPInput = z.object({
   address: z.string(),
-  state: z.string(),
 })
 
 export const GenerateEmailOTPOutput = z.string()
@@ -19,9 +19,10 @@ export const generateEmailOTPMethod = async ({
   input: GenerateEmailOTPParams
   ctx: Context
 }): Promise<string> => {
-  const { address, state } = input
+  const { address } = input
   const emailAddressNode = new EmailAddress(ctx.address as AddressNode)
 
+  const state = generateRandomString(12)
   const code = await emailAddressNode.generateVerificationCode(state)
   await ctx.emailClient.sendEmailNotification.mutate({
     emailAddress: address,

--- a/platform/address/src/jsonrpc/methods/getAddressProfile.ts
+++ b/platform/address/src/jsonrpc/methods/getAddressProfile.ts
@@ -1,6 +1,10 @@
 import { string, z } from 'zod'
 
-import { CryptoAddressType, OAuthAddressType } from '@kubelt/types/address'
+import {
+  CryptoAddressType,
+  EmailAddressType,
+  OAuthAddressType,
+} from '@kubelt/types/address'
 
 import { Context } from '../../context'
 import {
@@ -8,6 +12,7 @@ import {
   AppleProfileSchema,
   CryptoAddressProfileSchema,
   DiscordRawProfileSchema,
+  EmailProfileSchema,
   GithubRawProfileSubsetSchema,
   GoogleRawProfileSchema,
   MicrosoftRawProfileSchema,
@@ -21,6 +26,7 @@ import MicrosoftAddress from '../../nodes/microsoft'
 import AppleAddress from '../../nodes/apple'
 import DiscordAddress from '../../nodes/discord'
 import { AddressURNInput } from '@kubelt/platform-middleware/inputValidators'
+import EmailAddress from '../../nodes/email'
 
 export const GetAddressProfileOutput = z.discriminatedUnion('type', [
   z.object({
@@ -57,6 +63,11 @@ export const GetAddressProfileOutput = z.discriminatedUnion('type', [
     urn: AddressURNInput,
     profile: DiscordRawProfileSchema,
     type: z.literal(OAuthAddressType.Discord),
+  }),
+  z.object({
+    urn: AddressURNInput,
+    profile: EmailProfileSchema,
+    type: z.literal(EmailAddressType.Email),
   }),
 ])
 
@@ -147,13 +158,15 @@ export const getAddressProfileMethod = async ({
         profile,
       }
     }
-    // case OAuthAddressType.GitHub:
-    // case OAuthAddressType.Twitter:
-    // case OAuthAddressType.Google:
-    // case OAuthAddressType.Microsoft: {
-    //   const oAuthNode = new OAuthAddress(nodeClient)
-    //   return oAuthNode.getProfile()
-    // }
+    case EmailAddressType.Email: {
+      const emailNode = new EmailAddress(nodeClient)
+      const profile = await emailNode.getProfile()
+      return {
+        urn: ctx.addressURN,
+        type: EmailAddressType.Email,
+        profile,
+      }
+    }
     default:
       // if we don't have a profile at this point then something is wrong
       // profiles are set on OAuth nodes when setData is called

--- a/platform/address/src/jsonrpc/methods/resolveAccount.ts
+++ b/platform/address/src/jsonrpc/methods/resolveAccount.ts
@@ -56,7 +56,6 @@ export const resolveAccountMethod = async ({
       urn = AccountURNSpace.componentizedUrn(name)
       eventName = 'account-created'
     }
-
     const caller = appRouter.createCaller(ctx)
     await caller.setAccount(urn) // this will lazy create an account node when account worker is called
 

--- a/platform/address/src/jsonrpc/methods/verifyEmailOTP.ts
+++ b/platform/address/src/jsonrpc/methods/verifyEmailOTP.ts
@@ -2,10 +2,12 @@ import { z } from 'zod'
 import { Context } from '../../context'
 import { AddressNode } from '../../nodes'
 import EmailAddress from '../../nodes/email'
+import { appRouter } from '../router'
 
 export const VerifyEmailOTPInput = z.object({
   code: z.string(),
   state: z.string(),
+  jwt: z.string().optional(),
 })
 
 export const VerifyEmailOTPOutput = z.boolean()
@@ -19,7 +21,16 @@ export const verifyEmailOTPMethod = async ({
   input: GenerateEmailOTPParams
   ctx: Context
 }): Promise<z.infer<typeof VerifyEmailOTPOutput>> => {
-  const { code, state } = input
-  const emailClient = new EmailAddress(ctx.address as AddressNode)
-  return await emailClient.verifyCode(code, state)
+  const { code, state, jwt } = input
+  const emailAddressNode = new EmailAddress(ctx.address as AddressNode)
+  const successfulVerification = await emailAddressNode.verifyCode(code, state)
+  if (successfulVerification) {
+    const caller = appRouter.createCaller(ctx)
+    const { accountURN, existing } = await caller.resolveAccount({
+      jwt,
+      force: false,
+    })
+    //TODO: Authentication would happen based on the returned accountURN
+  }
+  return successfulVerification
 }

--- a/platform/address/src/jsonrpc/methods/verifyEmailOTP.ts
+++ b/platform/address/src/jsonrpc/methods/verifyEmailOTP.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+import { Context } from '../../context'
+import { AddressNode } from '../../nodes'
+import EmailAddress from '../../nodes/email'
+
+export const VerifyEmailOTPInput = z.object({
+  code: z.string(),
+  state: z.string(),
+})
+
+export const VerifyEmailOTPOutput = z.boolean()
+
+type GenerateEmailOTPParams = z.infer<typeof VerifyEmailOTPInput>
+
+export const verifyEmailOTPMethod = async ({
+  input,
+  ctx,
+}: {
+  input: GenerateEmailOTPParams
+  ctx: Context
+}): Promise<z.infer<typeof VerifyEmailOTPOutput>> => {
+  const { code, state } = input
+  const emailClient = new EmailAddress(ctx.address as AddressNode)
+  return await emailClient.verifyCode(code, state)
+}

--- a/platform/address/src/jsonrpc/middlewares/checkOAuthNode.ts
+++ b/platform/address/src/jsonrpc/middlewares/checkOAuthNode.ts
@@ -18,14 +18,14 @@ export const checkOAuthNode: BaseMiddlewareFunction<Context> = async ({
   console.log('checkOAuthNode: addrType', addrType)
 
   const nodeType = isOAuthAddressType(addrType)
-  if (addrType && !nodeType) {
-    throw `invalid oauth address type: ${addrType}`
+  if (nodeType) {
+    return next({
+      ctx: {
+        ...ctx,
+        nodeType,
+      },
+    })
+  } else {
+    return next({ ctx })
   }
-
-  return next({
-    ctx: {
-      ...ctx,
-      nodeType,
-    },
-  })
 }

--- a/platform/address/src/jsonrpc/router.ts
+++ b/platform/address/src/jsonrpc/router.ts
@@ -53,6 +53,16 @@ import {
   SetAddressNicknameInput,
   setAddressNicknameMethod,
 } from './methods/setAddressNickname'
+import {
+  GenerateEmailOTPInput,
+  generateEmailOTPMethod,
+  GenerateEmailOTPOutput,
+} from './methods/generateEmailOTP'
+import {
+  VerifyEmailOTPInput,
+  verifyEmailOTPMethod,
+  VerifyEmailOTPOutput,
+} from './methods/verifyEmailOTP'
 
 const t = initTRPC.context<Context>().create()
 
@@ -126,6 +136,22 @@ export const appRouter = t.router({
     .use(Analytics)
     .input(SetAddressNicknameInput)
     .query(setAddressNicknameMethod),
+  generateEmailOTP: t.procedure
+    .use(LogUsage)
+    .use(parse3RN)
+    .use(setAddressNodeClient)
+    .use(Analytics)
+    .input(GenerateEmailOTPInput)
+    .output(GenerateEmailOTPOutput)
+    .mutation(generateEmailOTPMethod),
+  verifyEmailOTP: t.procedure
+    .use(LogUsage)
+    .use(parse3RN)
+    .use(setAddressNodeClient)
+    .use(Analytics)
+    .input(VerifyEmailOTPInput)
+    .output(VerifyEmailOTPOutput)
+    .mutation(verifyEmailOTPMethod),
   getNonce: t.procedure
     .use(LogUsage)
     .use(parse3RN)

--- a/platform/address/src/jsonrpc/validators/profile.ts
+++ b/platform/address/src/jsonrpc/validators/profile.ts
@@ -122,6 +122,14 @@ export const DiscordRawProfileSchema = z.object({
   isDiscord: z.boolean().default(true),
 })
 
+export const EmailProfileSchema = z.object({
+  address: z.string(),
+  picture: z.string().optional(),
+  name: z.string().optional(),
+  email: z.string(),
+  isEmail: z.boolean().default(true),
+})
+
 export const AddressProfileSchema = z.union([
   CryptoAddressProfileSchema,
   GoogleRawProfileSchema,
@@ -130,4 +138,5 @@ export const AddressProfileSchema = z.union([
   MicrosoftRawProfileSchema,
   AppleProfileSchema,
   DiscordRawProfileSchema,
+  EmailProfileSchema,
 ])

--- a/platform/address/src/nodes/address.ts
+++ b/platform/address/src/nodes/address.ts
@@ -8,6 +8,7 @@ import type { Environment } from '../types'
 import ContractAddress from './contract'
 import CryptoAddress from './crypto'
 import OAuthAddress from './oauth'
+import EmailAddress from './email'
 
 export default class Address extends DOProxy {
   declare state: DurableObjectState
@@ -80,6 +81,8 @@ export default class Address extends DOProxy {
         return OAuthAddress.alarm(this)
       case NodeType.Contract:
         return ContractAddress.alarm(this)
+      case NodeType.Email:
+        return EmailAddress.alarm(this)
       default:
         console.log('Unknown node type', type)
     }

--- a/platform/address/src/nodes/email.ts
+++ b/platform/address/src/nodes/email.ts
@@ -1,0 +1,58 @@
+import generateRandomString from '@kubelt/utils/generateRandomString'
+import { DurableObjectStubProxy } from 'do-proxy'
+import { AddressNode } from '.'
+import { EMAIL_VERIFICATION_OPTIONS } from '../constants'
+import Address from './address'
+
+type EmailVerification = {
+  address: string
+  //Other things will need to go here, like redirectUri, scope, state, timestamp
+}
+
+export default class EmailAddress {
+  declare node: AddressNode
+
+  constructor(node: AddressNode) {
+    this.node = node
+  }
+
+  async generateVerificationCode(address: string): Promise<string> {
+    const code = generateRandomString(8)
+    const verificationCodes =
+      (await this.node.storage.get<Record<string, EmailVerification>>(
+        'codes'
+      )) || {}
+
+    verificationCodes[code] = {
+      address,
+    }
+
+    await this.node.storage.put('codes', verificationCodes)
+    await this.node.storage.setAlarm(
+      Date.now() + EMAIL_VERIFICATION_OPTIONS.ttlInMs
+    )
+
+    return code
+  }
+
+  async verifyCode(code: string): Promise<EmailVerification> {
+    const codes =
+      (await this.node.storage.get<Record<string, EmailVerification>>(
+        'codes'
+      )) || {}
+    const emailVerification = codes ? codes[code] : undefined
+    if (!codes || !emailVerification)
+      throw new Error('Verification code did not match.')
+
+    delete codes[code]
+
+    await this.node.storage.put('codes', codes)
+
+    return emailVerification
+  }
+
+  static async alarm(address: Address) {
+    console.log({ alarm: 'oauth' })
+  }
+}
+export type EmailAddressProxyStub = DurableObjectStubProxy<EmailAddress>

--- a/platform/address/src/nodes/email.ts
+++ b/platform/address/src/nodes/email.ts
@@ -40,7 +40,7 @@ export default class EmailAddress {
     }
 
     const creationTimestamp = Date.now()
-    const code = generateRandomString(8)
+    const code = generateRandomString(EMAIL_VERIFICATION_OPTIONS.codeLength)
     verificationCodes[code] = {
       state,
       creationTimestamp,

--- a/platform/address/src/nodes/email.ts
+++ b/platform/address/src/nodes/email.ts
@@ -1,8 +1,10 @@
+import { add } from '@dnd-kit/utilities'
 import { EmailAddressType, NodeType } from '@kubelt/types/address'
 import generateRandomString from '@kubelt/utils/generateRandomString'
 import { DurableObjectStubProxy } from 'do-proxy'
 import { AddressNode } from '.'
 import { EMAIL_VERIFICATION_OPTIONS } from '../constants'
+import { EmailAddressProfile } from '../types'
 import Address from './address'
 
 type VerificationPayload = {
@@ -101,6 +103,23 @@ export default class EmailAddress {
     }
 
     await address.state.storage.put(CODES_KEY_NAME, codes)
+  }
+
+  async getProfile(): Promise<EmailAddressProfile> {
+    const [nickname, gradient, address] = await Promise.all([
+      this.node.class.getNickname(),
+      this.node.class.getGradient(),
+      this.node.class.getAddress(),
+    ])
+    if (!address) throw new Error('Cannot load profile for email address node')
+    const result: EmailAddressProfile = {
+      address,
+      email: address,
+      isEmail: true,
+      name: nickname ?? address,
+      picture: gradient,
+    }
+    return result
   }
 }
 export type EmailAddressProxyStub = DurableObjectStubProxy<EmailAddress>

--- a/platform/address/src/types.ts
+++ b/platform/address/src/types.ts
@@ -13,6 +13,7 @@ import {
 } from './jsonrpc/validators/oauth'
 import {
   CryptoAddressProfileSchema,
+  EmailProfileSchema,
   NFTarVoucherSchema,
 } from './jsonrpc/validators/profile'
 import { DeploymentMetadata } from '@kubelt/types'
@@ -71,6 +72,7 @@ export type OAuthMicrosoftProfile = z.infer<
 >['_json']
 export type OAuthAppleProfile = z.infer<typeof AppleOAuthSchema>
 export type OAuthDiscordProfile = z.infer<typeof DiscordOAuthSchema>['__json']
+export type EmailAddressProfile = z.infer<typeof EmailProfileSchema>
 
 export type CryptoAddressProfile = z.infer<typeof CryptoAddressProfileSchema>
 export type AddressProfile =
@@ -81,6 +83,7 @@ export type AddressProfile =
   | OAuthMicrosoftProfile
   | OAuthAppleProfile
   | OAuthDiscordProfile
+  | EmailAddressProfile
 
 export type AddressProfiles = AddressProfile[]
 

--- a/platform/address/src/types.ts
+++ b/platform/address/src/types.ts
@@ -21,6 +21,7 @@ export interface Environment {
   Access: Fetcher
   Edges: Fetcher
   Images: Fetcher
+  Email: Fetcher
   Address: DurableObjectNamespace
   Analytics: AnalyticsEngineDataset
   ServiceDeploymentMetadata: DeploymentMetadata

--- a/platform/address/src/utils.ts
+++ b/platform/address/src/utils.ts
@@ -4,6 +4,7 @@ import { computeAddress } from '@ethersproject/transactions'
 
 import {
   CryptoAddressType,
+  EmailAddressType,
   HandleAddressType,
   NodeType,
   OAuthAddressType,
@@ -14,6 +15,7 @@ export const isNodeType = (type: string): type is NodeType => {
     case NodeType.Crypto:
     case NodeType.Contract:
     case NodeType.OAuth:
+    case NodeType.Email:
     case NodeType.Handle:
       return true
     default:
@@ -44,6 +46,15 @@ export const isOAuthAddressType = (type: string | undefined) => {
   }
 }
 
+export const isEmailAddressType = (type: string | undefined) => {
+  switch (type) {
+    case EmailAddressType.Email:
+      return NodeType.Email
+    default:
+      return false
+  }
+}
+
 export const isHandleAddressType = (type: string) => {
   switch (type) {
     case HandleAddressType.Handle:
@@ -57,6 +68,7 @@ export const isValidAddressType = (type: string) => {
   return (
     isCryptoAddressType(type) ||
     isOAuthAddressType(type) ||
+    isEmailAddressType(type) ||
     isHandleAddressType(type)
   )
 }

--- a/platform/address/wrangler.toml
+++ b/platform/address/wrangler.toml
@@ -4,28 +4,25 @@ compatibility_date = "2022-10-26"
 node_compat = true
 workers_dev = false
 
-durable_objects.bindings = [
-  { name = "Address", class_name = "Address" },
-]
+durable_objects.bindings = [{ name = "Address", class_name = "Address" }]
 
 services = [
   { binding = "Access", service = "access" },
   { binding = "Edges", service = "edges" },
-  { binding = "Images", service= "images"}
+  { binding = "Images", service = "images" },
+  { binding = "Email", service = "email" },
 ]
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalytics"  },
+  { binding = "Analytics", dataset = "PlatformAnalytics" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [vars]
-MINTPFP_CONTRACT_ADDRESS="0x028aE75Bb01eef2A581172607b93af8D24F50643"
-NFTAR_URL="https://test.nftar.rollup.id/api"
-NFTAR_CHAIN_ID=5
+MINTPFP_CONTRACT_ADDRESS = "0x028aE75Bb01eef2A581172607b93af8D24F50643"
+NFTAR_URL = "https://test.nftar.rollup.id/api"
+NFTAR_CHAIN_ID = 5
 
 [dev]
 port = 10102
@@ -55,79 +52,71 @@ deleted_classes = ["CryptoAddress"]
 new_classes = ["Address"]
 
 [env.dev]
-durable_objects.bindings = [
-  { name = "Address", class_name = "Address" },
-]
+durable_objects.bindings = [{ name = "Address", class_name = "Address" }]
 services = [
   { binding = "Access", service = "access-dev" },
   { binding = "Edges", service = "edges-dev" },
-  { binding = "Images", service= "images-dev"}
+  { binding = "Images", service = "images-dev" },
+  { binding = "Email", service = "email-dev" },
 ]
 kv_namespaces = [
-  { binding = "HANDLES", id = "fca42f2091f14eebb9226513ed8a4c09" }
+  { binding = "HANDLES", id = "fca42f2091f14eebb9226513ed8a4c09" },
 ]
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalyticsDev"  },
+  { binding = "Analytics", dataset = "PlatformAnalyticsDev" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [env.dev.vars]
-MINTPFP_CONTRACT_ADDRESS="0x028aE75Bb01eef2A581172607b93af8D24F50643"
-NFTAR_URL="https://test.nftar.rollup.id/api"
-NFTAR_CHAIN_ID=5
+MINTPFP_CONTRACT_ADDRESS = "0x028aE75Bb01eef2A581172607b93af8D24F50643"
+NFTAR_URL = "https://test.nftar.rollup.id/api"
+NFTAR_CHAIN_ID = 5
 
 [env.next]
-durable_objects.bindings = [
-  { name = "Address", class_name = "Address" },
-]
+durable_objects.bindings = [{ name = "Address", class_name = "Address" }]
 services = [
   { binding = "Access", service = "access-next" },
   { binding = "Edges", service = "edges-next" },
-  { binding = "Images", service= "images-next"}
+  { binding = "Images", service = "images-next" },
+  { binding = "Email", service = "email-next" },
+
 ]
 kv_namespaces = [
-  { binding = "HANDLES", id = "814a8ca024cd4fda8a667a4143cb4825" }
+  { binding = "HANDLES", id = "814a8ca024cd4fda8a667a4143cb4825" },
 ]
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalyticsNext"  },
+  { binding = "Analytics", dataset = "PlatformAnalyticsNext" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [env.next.vars]
-MINTPFP_CONTRACT_ADDRESS="0x028aE75Bb01eef2A581172607b93af8D24F50643"
-NFTAR_URL="https://test.nftar.rollup.id/api"
-NFTAR_CHAIN_ID=5
+MINTPFP_CONTRACT_ADDRESS = "0x028aE75Bb01eef2A581172607b93af8D24F50643"
+NFTAR_URL = "https://test.nftar.rollup.id/api"
+NFTAR_CHAIN_ID = 5
 
 [env.current]
-durable_objects.bindings = [
-  { name = "Address", class_name = "Address" },
-]
+durable_objects.bindings = [{ name = "Address", class_name = "Address" }]
 services = [
   { binding = "Access", service = "access-current" },
   { binding = "Edges", service = "edges-current" },
-  { binding = "Images", service= "images-current"}
+  { binding = "Images", service = "images-current" },
+  { binding = "Email", service = "email-current" },
 ]
 kv_namespaces = [
-  { binding = "HANDLES", id = "d7d0ac60a79f4848bf8372b01a487888" }
+  { binding = "HANDLES", id = "d7d0ac60a79f4848bf8372b01a487888" },
 ]
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalyticsCurrent"  },
+  { binding = "Analytics", dataset = "PlatformAnalyticsCurrent" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [env.current.vars]
-MINTPFP_CONTRACT_ADDRESS="0x3ebfaFE60F3Ac34f476B2f696Fc2779ff1B03193"
-NFTAR_URL="https://nftar.rollup.id/api"
-NFTAR_CHAIN_ID=1
+MINTPFP_CONTRACT_ADDRESS = "0x3ebfaFE60F3Ac34f476B2f696Fc2779ff1B03193"
+NFTAR_URL = "https://nftar.rollup.id/api"
+NFTAR_CHAIN_ID = 1

--- a/platform/email/src/jsonrpc/router.ts
+++ b/platform/email/src/jsonrpc/router.ts
@@ -11,7 +11,7 @@ import { Context } from '../context'
 const t = initTRPC.context<Context>().create()
 
 export const appRouter = t.router({
-  upload: t.procedure
+  sendEmailNotification: t.procedure
     .use(LogUsage)
     .use(Analytics)
     .input(sendOTPEmailMethodInput)

--- a/platform/email/wrangler.toml
+++ b/platform/email/wrangler.toml
@@ -10,7 +10,7 @@ port = 10105
 inspector_port = 11105
 local_protocol = "http"
 
-[env]
+[vars]
 NotificationFromName = "Rollup Local - Notification"
 NotificationFromUser = "noreplylocal"
 

--- a/platform/galaxy/src/schema/resolvers/address.ts
+++ b/platform/galaxy/src/schema/resolvers/address.ts
@@ -21,6 +21,7 @@ import {
   OAuthGoogleProfile,
   OAuthMicrosoftProfile,
   OAuthTwitterProfile,
+  EmailAddressProfile,
 } from '@kubelt/platform.address/src/types'
 import { PlatformAddressURNHeader } from '@kubelt/types/headers'
 import { EDGE_ADDRESS } from '@kubelt/platform.address/src/constants'
@@ -146,6 +147,10 @@ const addressResolvers: Resolvers = {
       if ((obj as unknown as OAuthDiscordProfile).isDiscord) {
         return 'OAuthDiscordProfile'
       }
+      if ((obj as unknown as EmailAddressProfile).isEmail) {
+        return 'EmailAddressProfile'
+      }
+
       return null
     },
   },

--- a/platform/galaxy/src/schema/types/address.ts
+++ b/platform/galaxy/src/schema/types/address.ts
@@ -54,6 +54,13 @@ export default /* GraphQL */ `
     sub: String
   }
 
+  type EmailAddressProfile {
+    address: String!
+    name: String
+    picture: String!
+    email: String
+  }
+
   type OAuthDiscordProfile {
     id: String
     email: String
@@ -70,6 +77,7 @@ export default /* GraphQL */ `
     | OAuthMicrosoftProfile
     | OAuthAppleProfile
     | OAuthDiscordProfile
+    | EmailAddressProfile
 
   type AddressProfile {
     urn: URN!


### PR DESCRIPTION
# Description

Implements Email OTP generation and verification, along with association with account (new or existing if JWT is provided). 

- Closes #1898

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
New accounts: 
1. `curl -H 'Content-Type: application/json' http://localhost:10401 -H 'Authorization: Bearer (jwt)' -d '{"query": "{ connectedAddresses { baseUrn, qc } } "}' `
2. `curl 'localhost:10001/connect/email/otp?address=blah2@blah.com'`
3. `curl 'localhost:10001/connect/email/otp' -X POST -H "Content-Type: application/x-www-form-urlencoded"  -d "address=blah2@blah.com&state=(state value from previous step)&code=(code from email in console)"`
4. Rerun step 1

For connecting to existing accounts
1. Log in to Passport and take note of the Passport cookie value.  
2. Repeat steps above with additional parameter of `-b '_rollup_session=(cookie value)'` in step 3. The results can also be viewed in the Profile app when logging on with the account the email was connected to.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
