### PR TITLE
fix(passport): provision appleid profile

### DIFF
--- a/apps/passport/app/routes/authenticate/$clientId.tsx
+++ b/apps/passport/app/routes/authenticate/$clientId.tsx
@@ -214,10 +214,12 @@ export default function Authenticate() {
                 }}
               >
                 <div className="flex flex-row items-center space-x-3">
-                  <img
-                    className="w-6 h-6 rounded-full"
-                    src={profile.pfp.image}
-                  />
+                  {profile.pfp?.image && (
+                    <img
+                      className="w-6 h-6 rounded-full"
+                      src={profile.pfp.image}
+                    />
+                  )}
                   <Text weight="medium" className="text-gray-800">
                     {profile.displayName}
                   </Text>

--- a/apps/passport/app/routes/connect/apple/callback.ts
+++ b/apps/passport/app/routes/connect/apple/callback.ts
@@ -68,9 +68,12 @@ export const loader: LoaderFunction = async ({ request, context }) => {
   const profile: OAuthAppleProfile = {
     provider: OAuthAddressType.Apple,
     email: token.email as string,
-    name: user?.name,
+    name: user?.name
+      ? `${user.name.firstName} ${user.name.lastName}`
+      : (token.email as string),
     sub: token.sub,
     picture: '',
+    isApple: true,
   }
 
   const address = AddressURNSpace.componentizedUrn(

--- a/apps/passport/app/utils/authenticate.server.ts
+++ b/apps/passport/app/utils/authenticate.server.ts
@@ -166,9 +166,16 @@ const provisionProfile = async (
             }
           }
           case OAuthAddressType.Apple: {
-            const { firstName, lastName } = res.profile.name!
+            let displayName = ''
+            if (res.profile.name) {
+              const { firstName, lastName } = res.profile.name
+              displayName = `${firstName} ${lastName}`
+            }
             return {
-              displayName: `${firstName} ${lastName}`,
+              displayName,
+              pfp: {
+                image: res.profile.picture,
+              },
             }
           }
           case OAuthAddressType.Discord: {

--- a/apps/passport/app/utils/authenticate.server.ts
+++ b/apps/passport/app/utils/authenticate.server.ts
@@ -166,13 +166,8 @@ const provisionProfile = async (
             }
           }
           case OAuthAddressType.Apple: {
-            let displayName = ''
-            if (res.profile.name) {
-              const { firstName, lastName } = res.profile.name
-              displayName = `${firstName} ${lastName}`
-            }
             return {
-              displayName,
+              displayName: res.profile.name,
               pfp: {
                 image: res.profile.picture,
               },

--- a/apps/profile/app/routes/account/connections/index.tsx
+++ b/apps/profile/app/routes/account/connections/index.tsx
@@ -98,7 +98,7 @@ const RenameModal = ({
           required
           heading=""
           name="name"
-          disabled={data.title.endsWith('.eth')}
+          disabled={data.title && data.title.endsWith('.eth')}
           defaultValue={data.title ?? ''}
         />
         <Text size="xs" weight="normal" className="text-gray-500 mt-2">
@@ -148,9 +148,13 @@ const DisconnectModal = ({
           </Text>
 
           <Text size="sm" weight="normal" className="text-gray-500 my-7">
-            Are you sure you want to disconnect {data.chain} account "
-            <span className="text-gray-800">{data.title}</span>" from Rollup?
-            You might lose access to some functionality.
+            Are you sure you want to disconnect {data.chain} account
+            {data.title && (
+              <>
+                "<span className="text-gray-800">{data.title}</span>"
+              </>
+            )}
+            from Rollup? You might lose access to some functionality.
           </Text>
 
           <fetcher.Form method="post" action="/account/connections/disconnect">

--- a/platform/access/src/jsonrpc/validators/IdTokenProfileSchema.ts
+++ b/platform/access/src/jsonrpc/validators/IdTokenProfileSchema.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod'
 
 const IdTokenProfileSchema = z.object({
-  name: z.string(),
-  picture: z.string(),
+  name: z.string().optional(),
+  picture: z.string().optional(),
 })
 
 export default IdTokenProfileSchema

--- a/platform/access/src/utils/getIdTokenProfileFromAccount.ts
+++ b/platform/access/src/utils/getIdTokenProfileFromAccount.ts
@@ -7,14 +7,13 @@ export default async function (
   ctx: Context
 ): Promise<IdTokenProfile> {
   const accountProfile = await ctx.accountClient.getProfile.query({ account })
-  if (!accountProfile || !accountProfile.displayName || !accountProfile.pfp) {
-    console.error('getIdTokenProfileForAccount', { accountProfile })
+  if (!accountProfile) {
     throw new Error(
       `Could not read account details for account ${account} to encode into ID token.`
     )
   }
   return {
     name: accountProfile?.displayName,
-    picture: accountProfile?.pfp.image,
+    picture: accountProfile?.pfp?.image,
   }
 }

--- a/platform/address/src/jsonrpc/validators/oauth.ts
+++ b/platform/address/src/jsonrpc/validators/oauth.ts
@@ -107,12 +107,7 @@ export const TwitterOAuthSchema = z.object({
 export const AppleOAuthSchema = z.object({
   provider: z.literal(OAuthAddressType.Apple),
   email: z.string(),
-  name: z
-    .object({
-      firstName: z.string(),
-      lastName: z.string(),
-    })
-    .optional(),
+  name: z.string().optional(),
   picture: z.string(),
   sub: z.string(),
   _json: z.undefined(),

--- a/platform/address/src/jsonrpc/validators/profile.ts
+++ b/platform/address/src/jsonrpc/validators/profile.ts
@@ -102,12 +102,7 @@ export const MicrosoftRawProfileSchema = z.object({
 
 export const AppleProfileSchema = z.object({
   email: z.string(),
-  name: z
-    .object({
-      firstName: z.string(),
-      lastName: z.string(),
-    })
-    .optional(),
+  name: z.string().optional(),
   picture: z.string(),
   sub: z.string(),
   isApple: z.boolean().default(true),


### PR DESCRIPTION
# Description

The profile data does not include `name` if the user has been authenticated
before.

The id token generation in the access worker requires a `pfp` set.

- Closes #1883

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual
  - [x] Connect as the main account
  - [x] Connect as an additional account
