### PR TITLE
chore(address): Remove unnecessary authorization call and Access service bindings.

### DIFF
--- a/apps/passport/app/routes/connect/$address/sign.tsx
+++ b/apps/passport/app/routes/connect/$address/sign.tsx
@@ -74,7 +74,7 @@ export const action: ActionFunction = async ({ request, context, params }) => {
   const formData = await request.formData()
 
   // TODO: validate from data
-  const { code, existing } = await addressClient.verifyNonce.mutate({
+  const { existing } = await addressClient.verifyNonce.mutate({
     nonce: formData.get('nonce') as string,
     signature: formData.get('signature') as string,
     jwt: await getJWTConditionallyFromSession(
@@ -93,7 +93,6 @@ export const action: ActionFunction = async ({ request, context, params }) => {
   const searchParams = new URL(request.url).searchParams
   searchParams.set('node_type', 'crypto')
   searchParams.set('addr_type', 'eth')
-  searchParams.set('code', code)
   const state = formData.get('state')
   if (state) {
     searchParams.set('state', state as string)

--- a/apps/passport/app/routes/connect/$address/token.tsx
+++ b/apps/passport/app/routes/connect/$address/token.tsx
@@ -14,9 +14,8 @@ export const loader: LoaderFunction = async ({ request, context, params }) => {
   const { address } = params
   const node_type = searchParams.get('node_type') as NodeType
   const addr_type = searchParams.get('addr_type') as AddressType
-  const code = searchParams.get('code') as string
 
-  if (!address || !node_type || !addr_type || !code) {
+  if (!address || !node_type || !addr_type) {
     throw json({ message: 'Invalid params' }, 400)
   }
 

--- a/platform/address/src/jsonrpc/methods/verifyNonce.ts
+++ b/platform/address/src/jsonrpc/methods/verifyNonce.ts
@@ -20,8 +20,6 @@ export const VerifyNonceInput = z.object({
 
 // TODO: move to shared validators?
 export const VerifyNonceOutput = z.object({
-  code: z.string(),
-  state: z.string(),
   existing: z.boolean(),
 })
 
@@ -38,34 +36,16 @@ export const verifyNonceMethod = async ({
   const { nonce, signature, jwt } = input
 
   const nodeClient = new CryptoAddress(ctx.address as AddressNode)
-  const {
-    address: clientId,
-    redirectUri,
-    scope,
-    state,
-  }: Challenge = await nodeClient.verifyNonce(nonce, signature)
+
+  await nodeClient.verifyNonce(nonce, signature)
 
   const caller = appRouter.createCaller(ctx)
-  const { accountURN, existing } = await caller.resolveAccount({
+  const { existing } = await caller.resolveAccount({
     jwt,
     force: input.forceAccountCreation,
   })
-  const responseType = ResponseType.Code
-
-  const accessClient = getAccessClient(ctx.Access, {
-    ...generateTraceContextHeaders(ctx.traceSpan),
-  })
-  const authorizeRes = await accessClient.authorize.mutate({
-    account: accountURN,
-    responseType,
-    clientId,
-    redirectUri,
-    scope,
-    state,
-  })
 
   return {
-    ...authorizeRes,
     existing,
   }
 }

--- a/platform/address/wrangler.toml
+++ b/platform/address/wrangler.toml
@@ -7,7 +7,6 @@ workers_dev = false
 durable_objects.bindings = [{ name = "Address", class_name = "Address" }]
 
 services = [
-  { binding = "Access", service = "access" },
   { binding = "Edges", service = "edges" },
   { binding = "Images", service = "images" },
   { binding = "Email", service = "email" },
@@ -54,7 +53,6 @@ new_classes = ["Address"]
 [env.dev]
 durable_objects.bindings = [{ name = "Address", class_name = "Address" }]
 services = [
-  { binding = "Access", service = "access-dev" },
   { binding = "Edges", service = "edges-dev" },
   { binding = "Images", service = "images-dev" },
   { binding = "Email", service = "email-dev" },
@@ -77,7 +75,6 @@ NFTAR_CHAIN_ID = 5
 [env.next]
 durable_objects.bindings = [{ name = "Address", class_name = "Address" }]
 services = [
-  { binding = "Access", service = "access-next" },
   { binding = "Edges", service = "edges-next" },
   { binding = "Images", service = "images-next" },
   { binding = "Email", service = "email-next" },
@@ -101,7 +98,6 @@ NFTAR_CHAIN_ID = 5
 [env.current]
 durable_objects.bindings = [{ name = "Address", class_name = "Address" }]
 services = [
-  { binding = "Access", service = "access-current" },
   { binding = "Edges", service = "edges-current" },
   { binding = "Images", service = "images-current" },
   { binding = "Email", service = "email-current" },


### PR DESCRIPTION
# Description

Removes unnecessary `authorize()` call in address worker and allows us to remove the Access service binding from it. Only affected wallet logins.

## Type of change

- Chore 

# How Has This Been Tested?

- Validated login with wallet
- Validated connected account with wallet
- Validated being unable to connect already connected wallet
- Validated error being produced in case of invalid nonce.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
