### PR TITLE
feat(platform): OIDC basic scope support (`email`, `profile`).

### DIFF
--- a/apps/console/app/routes/apps/$clientId/auth.tsx
+++ b/apps/console/app/routes/apps/$clientId/auth.tsx
@@ -132,7 +132,7 @@ export const loader: LoaderFunction = async ({ request, params, context }) => {
     ...generateTraceContextHeaders(context.traceSpan),
   })
 
-  const scopeMeta = await starbaseClient.getScopes.query()
+  const scopeMeta = await (await starbaseClient.getScopes.query()).scopes
 
   return json({ scopeMeta })
 }
@@ -416,7 +416,10 @@ export default function AppDetailIndexPage() {
                   <div className="flex-1">
                     <MultiSelect
                       label="Scopes"
-                      disabled={true}
+                      disabled={false}
+                      onChange={() => {
+                        setIsFormChanged(true)
+                      }}
                       fieldName="scopes"
                       items={Object.entries(scopeMeta).map(([key, value]) => {
                         return {

--- a/apps/passport/app/routes/authorize/index.tsx
+++ b/apps/passport/app/routes/authorize/index.tsx
@@ -13,8 +13,11 @@ import { getAccessClient, getStarbaseClient } from '~/platform.server'
 import { Authorization } from '~/components/authorization/Authorization'
 import { getValidatedSessionContext } from '~/session.server'
 import type { Profile } from '@proofzero/platform/account/src/types'
+import { validatePersonaData } from '@proofzero/security/persona'
+import { PersonaData } from '@proofzero/types/application'
 
 export const loader: LoaderFunction = async ({ request, context }) => {
+  console.debug('AUTHORIZE INDEX')
   const { clientId, redirectUri, scope, state } = context.consoleParams
   const { jwt, accountUrn } = await getValidatedSessionContext(
     request,
@@ -34,7 +37,8 @@ export const loader: LoaderFunction = async ({ request, context }) => {
         400
       )
     }
-    if (!scope.length || (scope.length == 1 && scope[0].trim() === 'openid')) {
+    console.debug('SCOPE BEFORE CHECK', scope)
+    if (!scope?.length || (scope.length == 1 && scope[0].trim() === 'openid')) {
       // auto authorize if no scope is provided or is set to only openid
 
       const responseType = ResponseType.Code
@@ -111,12 +115,24 @@ export const action: ActionFunction = async ({ request, context }) => {
   const responseType = ResponseType.Code
   const redirectUri = form.get('redirect_uri') as string
   const scope = (form.get('scopes') as string).split(',')
+  const personaData = JSON.parse(
+    form.get('personaData') as string
+  ) as PersonaData
   const state = form.get('state') as string
   const clientId = form.get('client_id') as string
 
   if (!accountUrn || !responseType || !redirectUri || !scope || !state) {
     throw json({ message: 'Missing required fields' }, 400)
   }
+
+  await validatePersonaData(
+    accountUrn,
+    personaData,
+    {
+      addressFetcher: context.env.Address,
+    },
+    context.traceSpan
+  )
 
   const accessClient = getAccessClient(context.env, context.traceSpan)
   const authorizeRes = await accessClient.authorize.mutate({
@@ -125,6 +141,7 @@ export const action: ActionFunction = async ({ request, context }) => {
     clientId,
     redirectUri,
     scope,
+    personaData,
     state,
   })
 
@@ -174,6 +191,18 @@ export default function Authorize() {
     form.append('state', state)
     form.append('client_id', clientId)
     form.append('redirect_uri', redirectOverride)
+
+    /* TODO: implement hookup for dropdown selection. 
+    form.append('personaData', JSON.stringify(personaData))
+
+    Will need to be set in the Authorization component itself based on 
+    user selection, having a structure as follows:
+    const personaData: PersonaData = {
+      email:
+        '${selectedEmailAddressUrn}',
+    }
+     */
+
     submit(form, { method: 'post' })
   }
 

--- a/apps/passport/app/routes/authorize/index.tsx
+++ b/apps/passport/app/routes/authorize/index.tsx
@@ -17,7 +17,6 @@ import { validatePersonaData } from '@proofzero/security/persona'
 import { PersonaData } from '@proofzero/types/application'
 
 export const loader: LoaderFunction = async ({ request, context }) => {
-  console.debug('AUTHORIZE INDEX')
   const { clientId, redirectUri, scope, state } = context.consoleParams
   const { jwt, accountUrn } = await getValidatedSessionContext(
     request,
@@ -37,7 +36,6 @@ export const loader: LoaderFunction = async ({ request, context }) => {
         400
       )
     }
-    console.debug('SCOPE BEFORE CHECK', scope)
     if (!scope?.length || (scope.length == 1 && scope[0].trim() === 'openid')) {
       // auto authorize if no scope is provided or is set to only openid
 
@@ -115,6 +113,8 @@ export const action: ActionFunction = async ({ request, context }) => {
   const responseType = ResponseType.Code
   const redirectUri = form.get('redirect_uri') as string
   const scope = (form.get('scopes') as string).split(',')
+  /* This stores the selection made from the user in the authorization
+  screen; gets validated and stored for later retrieval at token generation stage */
   const personaData = JSON.parse(
     form.get('personaData') as string
   ) as PersonaData

--- a/packages/design-system/src/atoms/form/MultiSelect.tsx
+++ b/packages/design-system/src/atoms/form/MultiSelect.tsx
@@ -27,6 +27,7 @@ export type MultiSelectProps = {
   items: SelectItem[]
   selectedItems?: SelectItem[]
   disabled?: boolean
+  onChange?: () => void
 }
 
 export function MultiSelect({
@@ -35,6 +36,7 @@ export function MultiSelect({
   items,
   disabled = false,
   selectedItems = [],
+  onChange,
 }: MultiSelectProps) {
   const [query, setQuery] = useState('')
   const [selectedValues, setSelectedValues] = useState(selectedItems)
@@ -56,10 +58,8 @@ export function MultiSelect({
       value={selectedValues}
       disabled={disabled}
       onChange={(e) => {
-        console.log({ e })
-        console.log({ selectedValues })
-
         setSelectedValues(e)
+        !!onChange && onChange()
       }}
       name={fieldName}
       multiple

--- a/packages/errors/index.ts
+++ b/packages/errors/index.ts
@@ -86,3 +86,12 @@ export class NotFoundError extends RollupError {
     super(options)
   }
 }
+
+export class InternalServerError extends RollupError {
+  constructor(options?: RollupErrorOptions) {
+    if (!options) options = {}
+    options.code = options.code ?? ERROR_CODES.INTERNAL_SERVER_ERROR
+    options.message = options.message ?? ERROR_MESSAGES.INTERNAL_SERVER_ERROR
+    super(options)
+  }
+}

--- a/packages/platform-clients/address.ts
+++ b/packages/platform-clients/address.ts
@@ -2,8 +2,12 @@ import { createTRPCProxyClient, httpBatchLink, loggerLink } from '@trpc/client'
 import { Router } from '@proofzero/types'
 import { trpcClientLoggerGenerator } from './utils'
 import { PlatformHeaders } from './base'
+import { PlatformAddressURNHeader } from '@proofzero/types/headers'
 
-export default (fetcher: Fetcher, headers: PlatformHeaders) =>
+export default (
+  fetcher: Fetcher,
+  headers: PlatformHeaders & { [PlatformAddressURNHeader]?: string }
+) =>
   createTRPCProxyClient<Router.AddressRouter>({
     links: [
       loggerLink({

--- a/packages/security/persona.ts
+++ b/packages/security/persona.ts
@@ -1,0 +1,159 @@
+import { AccessURN, AccessURNSpace } from '@proofzero/urns/access'
+import { AddressURN, AddressURNSpace } from '@proofzero/urns/address'
+import createEdgesClient from '@proofzero/platform-clients/edges'
+import createAddressClient from '@proofzero/platform-clients/address'
+import createAccessClient from '@proofzero/platform-clients/access'
+import {
+  generateTraceContextHeaders,
+  TraceSpan,
+} from '@proofzero/platform-middleware/trace'
+import { EdgeSpace, EdgeURN } from '@proofzero/urns/edge'
+import { AccountURN, AccountURNSpace } from '@proofzero/urns/account'
+import { PlatformAddressURNHeader } from '@proofzero/types/headers'
+import { BadRequestError, InternalServerError } from '@proofzero/errors'
+import { EmailAddressType, OAuthAddressType } from '@proofzero/types/address'
+import { PersonaData } from '@proofzero/types/application'
+
+export const EDGE_AUTHORIZES_REF_TO: EdgeURN = EdgeSpace.urn('authorizes/refTo')
+
+export async function validatePersonaData(
+  accountUrn: AccountURN,
+  personaData: PersonaData,
+  env: { addressFetcher: Fetcher },
+  traceSpan: TraceSpan
+): Promise<void> {
+  for (const [scopeName, claimValue] of Object.entries(personaData)) {
+    //TODO: Make this more generic to apply to any claims
+    if (scopeName === 'email') {
+      const addressUrnForEmail = claimValue
+      if (!AddressURNSpace.is(addressUrnForEmail))
+        throw new BadRequestError({
+          message: 'Bad data received for address identifier',
+        })
+
+      const addressClient = createAddressClient(env.addressFetcher, {
+        [PlatformAddressURNHeader]: addressUrnForEmail,
+        ...generateTraceContextHeaders(traceSpan),
+      })
+      const retrievedAccountUrn = await addressClient.getAccount.query()
+
+      if (retrievedAccountUrn !== accountUrn)
+        throw new BadRequestError({
+          message: 'Address provided does not belong to authenticated account',
+        })
+
+      const addressProfile = await addressClient.getAddressProfile.query()
+      if (
+        addressProfile.type !== OAuthAddressType.Google &&
+        addressProfile.type !== OAuthAddressType.Microsoft &&
+        addressProfile.type !== EmailAddressType.Email
+      )
+        throw new BadRequestError({
+          message: 'Address provided is not an email-compatible address',
+        })
+    }
+  }
+}
+
+/* Sets authorization references to other nodes in the graph. Assumes that
+ * validation has been executed and trusts validity of data being passed in */
+export async function setPersonaReferences(
+  accessNode: AccessURN,
+  scope: string[],
+  personaData: PersonaData,
+  env: {
+    edgesFetcher: Fetcher
+  },
+  traceSpan: TraceSpan
+) {
+  const edgesClient = createEdgesClient(
+    env.edgesFetcher,
+    generateTraceContextHeaders(traceSpan)
+  )
+  for (const scopeEntry of scope) {
+    //TODO: make this more generic so it applies to all claims
+    if (scopeEntry === 'email') {
+      const claimAddressUrnForEmail = personaData.email as AddressURN
+      const createdEdge = await edgesClient.makeEdge.mutate({
+        src: accessNode,
+        tag: EDGE_AUTHORIZES_REF_TO,
+        dst: claimAddressUrnForEmail,
+      })
+    }
+  }
+}
+
+export type ClaimValueType =
+  | string
+  | {
+      [K: string]: ClaimValueType
+    }
+
+export async function getClaimValues(
+  accountUrn: AccountURN,
+  clientId: string,
+  scope: string[],
+  env: {
+    accessFetcher?: Fetcher
+    edgesFetcher: Fetcher
+  },
+  traceSpan: TraceSpan,
+  preFetchedPersonaData?: PersonaData
+): Promise<Record<string, ClaimValueType>> {
+  let result: Record<string, ClaimValueType> = {}
+
+  let personaData = preFetchedPersonaData
+  if (!personaData) {
+    if (!env.accessFetcher)
+      throw new InternalServerError({ message: 'No access fetcher specified' })
+    const accessClient = createAccessClient(
+      env.accessFetcher,
+      generateTraceContextHeaders(traceSpan)
+    )
+    personaData = await accessClient.getPersonaData.query({
+      accountUrn,
+      clientId,
+    })
+  }
+
+  const accessId = `${AccountURNSpace.decode(accountUrn)}@${clientId}`
+  const accessUrn = AccessURNSpace.componentizedUrn(accessId)
+
+  const edgesClient = createEdgesClient(
+    env.edgesFetcher,
+    generateTraceContextHeaders(traceSpan)
+  )
+  for (const scopeClaim of scope) {
+    if (scopeClaim === 'email') {
+      const emailAddressUrn = personaData.email
+      const edgesResults = await edgesClient.getEdges.query({
+        query: {
+          src: { baseUrn: accessUrn },
+          dst: { baseUrn: emailAddressUrn },
+          tag: EDGE_AUTHORIZES_REF_TO,
+        },
+      })
+      console.debug('EDGE RESULTS', {
+        emailUrn: emailAddressUrn,
+        accessUrn: accessUrn,
+        meta: edgesResults.metadata,
+        edges: edgesResults.edges,
+      })
+      const emailAddress = edgesResults.edges[0].dst.qc.alias
+      result = { ...result, email: emailAddress }
+    } else if (scopeClaim === 'profile') {
+      const nodeResult = await edgesClient.findNode.query({
+        baseUrn: accountUrn,
+      })
+      if (nodeResult) {
+        result = {
+          ...result,
+          name: nodeResult.qc.name,
+          picture: nodeResult.qc.picture,
+        }
+      }
+    }
+  }
+
+  return result
+}

--- a/packages/security/persona.ts
+++ b/packages/security/persona.ts
@@ -22,6 +22,9 @@ export async function validatePersonaData(
   env: { addressFetcher: Fetcher },
   traceSpan: TraceSpan
 ): Promise<void> {
+  //If there's nothing to validate, return right away
+  if (!personaData) return
+
   for (const [scopeName, claimValue] of Object.entries(personaData)) {
     //TODO: Make this more generic to apply to any claims
     if (scopeName === 'email') {

--- a/packages/security/scopes.ts
+++ b/packages/security/scopes.ts
@@ -36,11 +36,10 @@ export type { Scope }
  */
 export const SCOPE_ADMIM: Scope = scope('scope://rollup.id/admin.admin')
 
-// IMPLIED
-export const SCOPE_OPENID: Scope = scope('scope://rollup.id/openid')
-
-// GENERAL
-
+//Standard OIDC email claim
+export const SCOPE_EMAIL: Scope = scope('email')
+export const SCOPE_PROFILE: Scope = scope('profile')
+export const SCOPE_OPENID: Scope = scope('openid')
 /**
  * The scope required to read account object.
  */
@@ -104,27 +103,37 @@ export const SCOPE_BLOCKCHAIN_ACCOUNT_TRANSACT: Scope = scope(
  * @alpha
  */
 export const SCOPES: ScopeMap = {
-  [SCOPE_PROFILE_READ]: {
-    name: 'Public Profile',
-    description: 'Read your profile data.',
-    class: 'account',
-  },
-  [SCOPE_PROFILE_WRITE]: {
-    name: 'Edit Profile',
-    description: 'Write your profile data.',
-    class: 'account',
-  },
-  [SCOPE_CONNECTED_ACCOUNTS_READ]: {
-    name: 'Connected Accounts',
-    description: 'Read your visible connected blockchain accounts.',
-    class: 'address',
-  },
   [SCOPE_OPENID]: {
     name: 'OpenID',
     description: 'Read your OpenID profile',
     class: 'implied',
   },
+  [SCOPE_EMAIL]: {
+    name: 'Email',
+    description: 'Read your chosen email address',
+    class: 'address',
+  },
+  [SCOPE_PROFILE]: {
+    name: 'Profile',
+    description: 'Read a basic profile of your account',
+    class: 'profile',
+  },
   // NOT READY YET
+  // [SCOPE_PROFILE_READ]: {
+  //   name: 'Public Profile',
+  //   description: 'Read your profile data.',
+  //   class: 'account',
+  // },
+  // [SCOPE_PROFILE_WRITE]: {
+  //   name: 'Edit Profile',
+  //   description: 'Write your profile data.',
+  //   class: 'account',
+  // },
+  // [SCOPE_CONNECTED_ACCOUNTS_READ]: {
+  //   name: 'Connected Accounts',
+  //   description: 'Read your visible connected blockchain accounts.',
+  //   class: 'address',
+  // },
   // [SCOPE_BLOCKCHAIN_ACCOUNT_MANAGE]: {
   //   name: 'Create Dedicated Blockchain Account',
   //   description:

--- a/packages/types/application.ts
+++ b/packages/types/application.ts
@@ -1,5 +1,17 @@
+import { z } from 'zod'
+
+//TODO: Will have to revise and integrated with Scope in next iteration
+export const ClaimName = z.union([z.literal('email'), z.literal('openid')])
+export type ClaimName = z.infer<typeof ClaimName>
+
+export const ClaimValue = z.any()
+export type ClaimValue = z.infer<typeof ClaimValue>
+
 export type ScopeMeta = {
-  name: string
+  name: ClaimName
   description: string
   class: string
 }
+
+export const PersonaData = z.record(ClaimName, ClaimValue)
+export type PersonaData = z.infer<typeof PersonaData>

--- a/platform/access/src/errors.ts
+++ b/platform/access/src/errors.ts
@@ -37,6 +37,10 @@ export const InvalidClientCredentialsError = new BadRequestError({
   message: 'invalid client credentials',
 })
 
+export const ExpiredCodeError = new UnauthorizedError({
+  message: 'expired code',
+})
+
 export const ExpiredTokenError = new UnauthorizedError({
   message: 'expired token',
 })

--- a/platform/access/src/jsonrpc/methods/authorize.ts
+++ b/platform/access/src/jsonrpc/methods/authorize.ts
@@ -7,6 +7,7 @@ import { CODE_OPTIONS } from '../../constants'
 import { initAuthorizationNodeByName } from '../../nodes'
 import { hexlify } from '@ethersproject/bytes'
 import { randomBytes } from '@ethersproject/random'
+import { PersonaData } from '@proofzero/types/application'
 
 export const AuthorizeMethodInput = z.object({
   account: AccountURNInput,
@@ -14,6 +15,7 @@ export const AuthorizeMethodInput = z.object({
   clientId: z.string(),
   redirectUri: z.string(),
   scope: z.array(z.string()),
+  personaData: PersonaData.optional(),
   state: z.string(),
 })
 
@@ -31,7 +33,15 @@ export const authorizeMethod = async ({
   input: AuthorizeParams
   ctx: Context
 }) => {
-  const { account, responseType, clientId, redirectUri, scope, state } = input
+  const {
+    account,
+    responseType,
+    clientId,
+    redirectUri,
+    scope,
+    personaData,
+    state,
+  } = input
 
   const code = hexlify(randomBytes(CODE_OPTIONS.length))
 
@@ -45,7 +55,8 @@ export const authorizeMethod = async ({
     clientId,
     redirectUri,
     scope,
-    state
+    state,
+    personaData
   )
 
   return { ...result }

--- a/platform/access/src/jsonrpc/methods/exchangeToken.ts
+++ b/platform/access/src/jsonrpc/methods/exchangeToken.ts
@@ -176,11 +176,12 @@ const handleAuthorizationCode: ExchangeTokenMethod<
   const account = (await authorizationNode.storage.get<AccountURN>(
     'account'
   )) as AccountURN
-  const scope: string[] =
-    (await authorizationNode.storage.get<Scope>('scope')) || []
-  const personaData: PersonaData =
-    (await authorizationNode.storage.get<PersonaData>('personaData')) || {}
-
+  const resultMap = await authorizationNode.storage.get([
+    'scope',
+    'personaData',
+  ])
+  const scope = resultMap.get('scope') as string[]
+  const personaData = resultMap.get('personaData') as PersonaData
   const name = `${AccountURNSpace.decode(account)}@${clientId}`
   const accessNode = await initAccessNodeByName(name, ctx.Access)
   const { expirationTime } = ACCESS_TOKEN_OPTIONS

--- a/platform/access/src/jsonrpc/methods/exchangeToken.ts
+++ b/platform/access/src/jsonrpc/methods/exchangeToken.ts
@@ -22,6 +22,11 @@ import {
   MissingSubjectError,
   UnsupportedGrantTypeError,
 } from '../../errors'
+import { PersonaData } from '@proofzero/types/application'
+import {
+  getClaimValues,
+  setPersonaReferences,
+} from '@proofzero/security/persona'
 
 const AuthenticationCodeInput = z.object({
   grantType: z.literal(GrantType.AuthenticationCode),
@@ -171,15 +176,30 @@ const handleAuthorizationCode: ExchangeTokenMethod<
   const account = (await authorizationNode.storage.get<AccountURN>(
     'account'
   )) as AccountURN
-  const scope: string[] = []
+  const scope: string[] =
+    (await authorizationNode.storage.get<Scope>('scope')) || []
+  const personaData: PersonaData =
+    (await authorizationNode.storage.get<PersonaData>('personaData')) || {}
 
   const name = `${AccountURNSpace.decode(account)}@${clientId}`
   const accessNode = await initAccessNodeByName(name, ctx.Access)
-  const idTokenProfile = await getIdTokenProfileFromAccount(account, ctx)
   const { expirationTime } = ACCESS_TOKEN_OPTIONS
   const issuer = ctx.INTERNAL_JWT_ISS
 
-  await accessNode.storage.put({ account, clientId })
+  await accessNode.storage.put({ account, clientId, personaData })
+  const access = AccessURNSpace.componentizedUrn(name, { client_id: clientId })
+  await ctx.edgesClient!.makeEdge.mutate({
+    src: account,
+    dst: access,
+    tag: EDGE_AUTHORIZES,
+  })
+  await setPersonaReferences(
+    access,
+    scope,
+    personaData,
+    { edgesFetcher: ctx.Edges },
+    ctx.traceSpan
+  )
 
   const accessToken = await accessNode.class.generateAccessToken({
     account,
@@ -196,19 +216,22 @@ const handleAuthorizationCode: ExchangeTokenMethod<
     scope,
   })
 
+  //TODO: this will need to use a more specific getIdTokenClaimValues()
+  //in the next iteration of this
+  const idTokenClaims = await getClaimValues(
+    account,
+    clientId,
+    scope,
+    { edgesFetcher: ctx.Edges },
+    ctx.traceSpan,
+    personaData
+  )
   const idToken = await accessNode.class.generateIdToken({
     account,
     clientId,
     expirationTime,
-    idTokenProfile,
+    idTokenClaims: idTokenClaims,
     issuer,
-  })
-
-  const access = AccessURNSpace.componentizedUrn(name, { client_id: clientId })
-  await ctx.edgesClient!.makeEdge.mutate({
-    src: account,
-    dst: access,
-    tag: EDGE_AUTHORIZES,
   })
 
   return { accessToken, refreshToken, idToken }

--- a/platform/access/src/jsonrpc/methods/getPersonaData.ts
+++ b/platform/access/src/jsonrpc/methods/getPersonaData.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod'
+
+import { BadRequestError } from '@proofzero/errors'
+import { AccountURNSpace } from '@proofzero/urns/account'
+
+import { Context } from '../../context'
+import { initAccessNodeByName } from '../../nodes'
+import { PersonaData } from '@proofzero/types/application'
+
+export const GetPersonaDataInput = z.object({
+  accountUrn: z.string(),
+  clientId: z.string(),
+})
+
+export const GetPersonaDataOutput = PersonaData
+
+export const getPersonaDataMethod = async ({
+  input,
+  ctx,
+}: {
+  input: z.infer<typeof GetPersonaDataInput>
+  ctx: Context
+}): Promise<z.infer<typeof GetPersonaDataOutput>> => {
+  const { accountUrn, clientId } = input
+
+  if (!clientId)
+    throw new BadRequestError({
+      message: 'missing client id',
+    })
+
+  if (!AccountURNSpace.is(accountUrn))
+    throw new BadRequestError({
+      message: 'missing account',
+    })
+
+  const name = `${AccountURNSpace.decode(accountUrn)}@${clientId}`
+  const accessNode = await initAccessNodeByName(name, ctx.Access)
+
+  const personaData =
+    (await accessNode.storage.get<PersonaData>('personaData')) || {}
+  return personaData
+}

--- a/platform/access/src/jsonrpc/router.ts
+++ b/platform/access/src/jsonrpc/router.ts
@@ -55,6 +55,11 @@ import {
   RevokeAppAuthorizationMethodOutput,
   revokeAppAuthorizationMethod,
 } from './methods/revokeAppAuthorization'
+import {
+  GetPersonaDataInput,
+  getPersonaDataMethod,
+  GetPersonaDataOutput,
+} from './methods/getPersonaData'
 
 const t = initTRPC.context<Context>().create({ errorFormatter })
 
@@ -124,6 +129,12 @@ export const appRouter = t.router({
     .input(GetUserInfoInput)
     .output(GetUserInfoOutput)
     .query(getUserInfoMethod),
+  getPersonaData: t.procedure
+    .use(LogUsage)
+    .use(Analytics)
+    .input(GetPersonaDataInput)
+    .output(GetPersonaDataOutput)
+    .query(getPersonaDataMethod),
   getAuthorizedAppScopes: t.procedure
     .use(LogUsage)
     .use(Analytics)

--- a/platform/access/src/nodes/access.ts
+++ b/platform/access/src/nodes/access.ts
@@ -18,6 +18,7 @@ import {
   TokenClaimValidationFailedError,
   TokenVerificationFailedError,
 } from '../errors'
+import { ClaimValueType } from '@proofzero/security/persona'
 
 type TokenStore = DurableObjectStorage | DurableObjectTransaction
 
@@ -53,7 +54,7 @@ type IdTokenOptions = {
   clientId: string
   expirationTime: string
   issuer: string
-  idTokenProfile: IdTokenProfile
+  idTokenClaims: Record<string, ClaimValueType>
 }
 
 export default class Access extends DOProxy {
@@ -110,11 +111,10 @@ export default class Access extends DOProxy {
   }
 
   async generateIdToken(options: IdTokenOptions): Promise<string> {
-    const { account, clientId, expirationTime, idTokenProfile, issuer } =
-      options
+    const { account, clientId, expirationTime, idTokenClaims, issuer } = options
     const { alg } = JWT_OPTIONS
     const { privateKey: key } = await this.getJWTSigningKeyPair()
-    return new jose.SignJWT(idTokenProfile)
+    return new jose.SignJWT(idTokenClaims)
       .setProtectedHeader({ alg })
       .setExpirationTime(expirationTime)
       .setAudience([clientId])

--- a/platform/edges/src/db/select.ts
+++ b/platform/edges/src/db/select.ts
@@ -194,7 +194,7 @@ export async function node(
       urn=?
       `
     prepBindParams.push(baseUrnCondition)
-    conditionsStatement = `intersection as (${statement}) `
+    conditionsStatement = `intersector as (${statement}) `
   }
 
   const finalSqlStatement = sqlBase + conditionsStatement + sqlSuffix

--- a/platform/starbase/src/jsonrpc/validators/app.ts
+++ b/platform/starbase/src/jsonrpc/validators/app.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export const ScopeMeta = z.record(
-  z.string().refine((k) => k.startsWith('scope://')),
+  z.string(),
   z.object({
     name: z.string(),
     description: z.string(),


### PR DESCRIPTION
# Description

Implements the necessary bits to support functionality for OIDC scopes `email` and `profile`, including accepting the selection of a email-based connected account URN to populate the email claim value in the ID token.

Console now supports settings default scopes in the OAuth page. 

Note: currently only works for authorizations for apps owned by currently logged in user. See #2011

- Closes #1976

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Context:
- App created in Console with `email`, `profile` and `openid` scopes.
- Connected an email-based account to my account and noted its addressUrn.
- Hardcoded the addressUrn in `authorize/index.tsx` in the ActionFunction to send it's value in the `personaData` param of the `formData`.

1. Send request to `/authorize` with client ID and scope params matching app created in Console. This should ask you to log in, and present authorization screen. Once authorized, should redirect you to the redirect URI with the code in its queryParam.
2. Take the code in the queryParam from step 1, and make call to `/token` with it. You should get the token set. Verify scope field of access token; verify ID token claims requested and their values.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
