### PR TITLE
fix(passport): discord user icon

### DIFF
--- a/apps/passport/app/utils/profile.ts
+++ b/apps/passport/app/utils/profile.ts
@@ -59,7 +59,7 @@ export const normalizeProfileToConnection = (profile: any) => {
         id: profile.urn,
         address: `${profile.username}#${profile.discriminator}`,
         title: profile.username,
-        icon: `https://cdn.discordapp.com/avatars/${profile.discordId}/${profile.avatar}.png`,
+        icon: `https://cdn.discordapp.com/avatars/${profile.id}/${profile.avatar}.png`,
         type: 'Discord',
       }
     case EmailAddressType.Email:


### PR DESCRIPTION
# Description

[galaxy-client](https://github.com/proofzero/rollupid/blob/b591f8f65de7db56bbc3254b0a3e47bf0140b7b8/packages/galaxy-client/gql/address.graphql#L49) applies a field alias: `id` => `discordId` which was implemented to
overcome type difference on the `id` field in Discord type. This alias
doesn't apply in the profile data original source which the passport
application gets.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Manual