### PR TITLE
fix(platform): Tweak JSON error wrapper to allow using explicit `throw` statements

### DIFF
--- a/apps/passport/app/routes/authorize/index.tsx
+++ b/apps/passport/app/routes/authorize/index.tsx
@@ -40,7 +40,7 @@ import type { AddressURN } from '@proofzero/urns/address'
 import type { DataForScopes } from '~/utils/authorize.server'
 import { Text } from '@proofzero/design-system'
 import { BadRequestError } from '@proofzero/errors'
-import { throwJSONError } from '@proofzero/utils/errors'
+import { JsonError } from '@proofzero/utils/errors'
 
 export type UserProfile = {
   displayName: string
@@ -174,7 +174,7 @@ export const loader: LoaderFunction = async ({ request, context }) => {
     })
   } catch (e) {
     console.error(e)
-    throwJSONError(e)
+    throw JsonError(e)
   }
 }
 

--- a/apps/passport/app/routes/connect/email/otp.ts
+++ b/apps/passport/app/routes/connect/email/otp.ts
@@ -1,7 +1,7 @@
 import { EmailAddressType, NodeType } from '@proofzero/types/address'
 import { AddressURNSpace } from '@proofzero/urns/address'
 import { generateHashedIDRef } from '@proofzero/urns/idref'
-import { throwJSONError } from '@proofzero/utils/errors'
+import { JsonError } from '@proofzero/utils/errors'
 import { json } from '@remix-run/cloudflare'
 import { getAddressClient } from '~/platform.server'
 
@@ -32,7 +32,7 @@ export const loader: LoaderFunction = async ({ request, context }) => {
     return json({ state })
   } catch (e) {
     console.error('Error generating email OTP', e)
-    throwJSONError(e)
+    throw JsonError(e)
   }
 }
 

--- a/apps/passport/app/routes/token.tsx
+++ b/apps/passport/app/routes/token.tsx
@@ -2,7 +2,7 @@ import { ActionFunction, redirect } from '@remix-run/cloudflare'
 import { json } from '@remix-run/cloudflare'
 
 import { GrantType } from '@proofzero/types/access'
-import { throwJSONError } from '@proofzero/utils/errors'
+import { JsonError } from '@proofzero/utils/errors'
 
 import createAccessClient from '@proofzero/platform-clients/access'
 import { generateTraceContextHeaders } from '@proofzero/platform-middleware/trace'
@@ -26,17 +26,17 @@ export const action: ActionFunction = async ({ request, context }) => {
   try {
     const tokens = refreshToken
       ? await accessClient.exchangeToken.mutate({
-        grantType: GrantType.RefreshToken,
-        refreshToken,
-        clientId,
-        clientSecret,
-      })
+          grantType: GrantType.RefreshToken,
+          refreshToken,
+          clientId,
+          clientSecret,
+        })
       : await accessClient.exchangeToken.mutate({
-        grantType: GrantType.AuthorizationCode,
-        code,
-        clientId,
-        clientSecret,
-      })
+          grantType: GrantType.AuthorizationCode,
+          code,
+          clientId,
+          clientSecret,
+        })
 
     const result = {
       token_type: 'Bearer',
@@ -54,6 +54,6 @@ export const action: ActionFunction = async ({ request, context }) => {
       },
     })
   } catch (error) {
-    throwJSONError(error)
+    throw JsonError(error)
   }
 }

--- a/apps/passport/app/utils/authenticate.server.ts
+++ b/apps/passport/app/utils/authenticate.server.ts
@@ -2,7 +2,7 @@ import { AddressURNSpace } from '@proofzero/urns/address'
 import type { AddressURN } from '@proofzero/urns/address'
 import type { AccountURN } from '@proofzero/urns/account'
 
-import { throwJSONError } from '@proofzero/utils/errors'
+import { JsonError } from '@proofzero/utils/errors'
 import { GrantType, ResponseType } from '@proofzero/types/access'
 
 import {
@@ -108,7 +108,7 @@ export const authenticateAddress = async (
       appData?.clientId
     )
   } catch (error) {
-    throwJSONError(error)
+    throw JsonError(error)
   }
 }
 

--- a/packages/utils/errors.ts
+++ b/packages/utils/errors.ts
@@ -52,7 +52,7 @@ export const getErrorCause = (error: unknown): Error => {
   }
 }
 
-export const throwJSONError = (error: unknown): void => {
+export const JsonError = (error: unknown) => {
   let cause
 
   try {
@@ -60,7 +60,7 @@ export const throwJSONError = (error: unknown): void => {
   } catch (e) {
     console.error('Error handling error', e)
 
-    throw json(
+    return json(
       {
         message: 'unknown error',
       },
@@ -70,10 +70,10 @@ export const throwJSONError = (error: unknown): void => {
   const body = { ...cause, message: cause.message }
   if (cause instanceof RollupError) {
     const status = HTTP_STATUS_CODES[cause.code]
-    throw json(body, status)
+    return json(body, status)
   } else if (cause instanceof TRPCClientError) {
-    throw json(body, cause.data.httpStatus)
+    return json(body, cause.data.httpStatus)
   } else {
-    throw json(body, 500)
+    return json(body, 500)
   }
 }


### PR DESCRIPTION
# Description

Tweak JSON error wrapper to allow using explicit `throw` statements. This helps the type system indentify throw statements as execution control statements

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Made multiple `/authorize` calls with wrong parameters to trigger different errors that get thrown with the new `JsonError()` wrapper

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
