### PR TITLE
fix(passport): Fix encoding of scope values when switching from internal to external representation.

### DIFF
--- a/apps/passport/app/utils/authenticate.server.ts
+++ b/apps/passport/app/utils/authenticate.server.ts
@@ -32,7 +32,7 @@ export const authenticateAddress = async (
     clientId: string
     redirectUri: string
     state: string
-    scope: string
+    scope: string[]
     prompt: string
   } | null,
   env: Env,
@@ -94,7 +94,7 @@ export const authenticateAddress = async (
         client_id: authAppId,
         redirect_uri: authRedirectUri,
         state: authState,
-        scope: authScope,
+        scope: authScope.join(' '),
       })
 
       redirectURL += `?${urlParams}`


### PR DESCRIPTION
# Description

Addresses issues with encoding of scope values externally (space delimited) vs internally (string array).

- Closes #2044

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Login to Passport Settings and log out
- Craft authorization request with multiple scope values. Should present with login screen (authenticate with OAuth to take you away from current origin). Once you're redirected back, the authz with the right scopes should be presented.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
