### PR TITLE
fix(passport): Clear console param cookies on authz screen cancellation

### DIFF
--- a/apps/passport/app/routes/authorize/index.tsx
+++ b/apps/passport/app/routes/authorize/index.tsx
@@ -196,7 +196,21 @@ export const action: ActionFunction = async ({ request, context }) => {
   const cancel = form.get('cancel') as string
 
   if (cancel) {
-    return redirect(cancel)
+    const headers = new Headers()
+    const lastCP = await getConsoleParams(request, context.env)
+    if (lastCP) {
+      headers.append(
+        'Set-Cookie',
+        await destroyConsoleParamsSession(request, context.env, lastCP.clientId)
+      )
+
+      headers.append(
+        'Set-Cookie',
+        await destroyConsoleParamsSession(request, context.env)
+      )
+    }
+
+    return redirect(cancel, { headers })
   }
 
   const responseType = ResponseType.Code

--- a/apps/passport/app/routes/authorize/index.tsx
+++ b/apps/passport/app/routes/authorize/index.tsx
@@ -168,16 +168,19 @@ export const loader: LoaderFunction = async ({ request, context }) => {
       context.traceSpan
     )
 
-    return json<LoaderData>({
-      redirectUri,
-      clientId,
-      appProfile: appPublicProps,
-      scopeMeta: scopeMeta,
-      state,
-      redirectOverride: redirectUri,
-      scopeOverride: scope || [],
-      dataForScopes,
-    })
+    return json<LoaderData>(
+      {
+        redirectUri,
+        clientId,
+        appProfile: appPublicProps,
+        scopeMeta: scopeMeta,
+        state,
+        redirectOverride: redirectUri,
+        scopeOverride: scope || [],
+        dataForScopes,
+      },
+      { headers }
+    )
   } catch (e) {
     console.error(e)
     throw JsonError(e)
@@ -196,21 +199,7 @@ export const action: ActionFunction = async ({ request, context }) => {
   const cancel = form.get('cancel') as string
 
   if (cancel) {
-    const headers = new Headers()
-    const lastCP = await getConsoleParams(request, context.env)
-    if (lastCP) {
-      headers.append(
-        'Set-Cookie',
-        await destroyConsoleParamsSession(request, context.env, lastCP.clientId)
-      )
-
-      headers.append(
-        'Set-Cookie',
-        await destroyConsoleParamsSession(request, context.env)
-      )
-    }
-
-    return redirect(cancel, { headers })
+    return redirect(cancel)
   }
 
   const responseType = ResponseType.Code


### PR DESCRIPTION
# Description

When hitting Cancel on the authz screen, the console param cookies get deleted before the redirect.

- Closes #2046

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Craft request to get the authz screen. Copy the URL
- Hit cancel. You should be redirected to the redirect_uri with some query params
- Paste the URL from step 1 and try again, you should be presented with a login screen before getting to authz screen.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
