### PR TITLE
fix(passport): Adds checks to authenticate each unique authorization.

### DIFF
--- a/apps/passport/app/routes/authorize.tsx
+++ b/apps/passport/app/routes/authorize.tsx
@@ -386,18 +386,19 @@ export default function Authorize() {
   }
 
   const authorizeCallback = async (scopes: string[]) => {
-    if (!selectedEmail || !('addressURN' in selectedEmail)) return
-
     const form = new FormData()
     form.append('scopes', scopes.join(' '))
     form.append('state', state)
     form.append('client_id', clientId)
     form.append('redirect_uri', redirectOverride)
+    // TODO: Everything should be a form field now handled by javascript
+    // This helps keeps things generic has if a form input is not present
+    // it doesn't end up being submitted
     form.append(
       'personaData',
       JSON.stringify({
         ...persona,
-        email: selectedEmail.addressURN,
+        email: selectedEmail?.addressURN,
       })
     )
 
@@ -555,10 +556,12 @@ export default function Authorize() {
                   btnSize="xl"
                   btnType="primary-alt"
                   disabled={
+                    // TODO: make generic!
                     requestedScope.includes('email') &&
                     (!connectedEmails?.length || !selectedEmail)
                   }
                   onClick={() => {
+                    console.debug('I AM CLICKED', requestedScope)
                     authorizeCallback(requestedScope)
                   }}
                 >

--- a/apps/passport/app/routes/authorize.tsx
+++ b/apps/passport/app/routes/authorize.tsx
@@ -561,7 +561,6 @@ export default function Authorize() {
                     (!connectedEmails?.length || !selectedEmail)
                   }
                   onClick={() => {
-                    console.debug('I AM CLICKED', requestedScope)
                     authorizeCallback(requestedScope)
                   }}
                 >

--- a/apps/passport/app/session.server.ts
+++ b/apps/passport/app/session.server.ts
@@ -239,7 +239,10 @@ export async function getConsoleParams(
       const externalEncodedCookie = JSON.parse(session.get('params'))
       //Convert space-delimited scope to string array
       const { scope, ...otherProps } = externalEncodedCookie
-      return { ...otherProps, scope: scope.split(' ') }
+      return {
+        ...otherProps,
+        scope: scope.trim().length ? scope.split(' ') : [],
+      }
     })
     .catch((err) => {
       console.log('No console params session found')

--- a/apps/passport/app/utils/authenticate.server.ts
+++ b/apps/passport/app/utils/authenticate.server.ts
@@ -10,11 +10,7 @@ import {
   getAccountClient,
   getAddressClient,
 } from '~/platform.server'
-import {
-  createUserSession,
-  destroyConsoleParamsSession,
-  parseJwt,
-} from '~/session.server'
+import { createUserSession, parseJwt } from '~/session.server'
 import {
   CryptoAddressType,
   EmailAddressType,

--- a/packages/design-system/src/atoms/email/EmailSelect.tsx
+++ b/packages/design-system/src/atoms/email/EmailSelect.tsx
@@ -70,7 +70,8 @@ export const EmailSelect = ({
             )}
 
             <Text size="sm" className="bg-white flex-1 text-left text-gray-800">
-              {selected?.email ?? 'None'}
+              {selected?.email ??
+                (enableAddNew ? 'Connect new email address' : 'None')}
             </Text>
             {open ? (
               <ChevronDownIcon className="w-5 h-5 rotate-180" />

--- a/packages/design-system/src/atoms/email/EmailSelect.tsx
+++ b/packages/design-system/src/atoms/email/EmailSelect.tsx
@@ -69,10 +69,22 @@ export const EmailSelect = ({
               <MdOutlineAlternateEmail className="w-4 h-4 mr-3" />
             )}
 
-            <Text size="sm" className="bg-white flex-1 text-left text-gray-800">
-              {selected?.email ??
-                (enableAddNew ? 'Connect new email address' : 'None')}
-            </Text>
+            {!selected && (
+              <Text
+                size="sm"
+                className="bg-white flex-1 text-left text-gray-400"
+              >
+                {enableAddNew ? 'Connect new email address' : 'None'}
+              </Text>
+            )}
+            {selected && (
+              <Text
+                size="sm"
+                className="bg-white flex-1 text-left text-gray-800"
+              >
+                {selected?.email}
+              </Text>
+            )}
             {open ? (
               <ChevronDownIcon className="w-5 h-5 rotate-180" />
             ) : (


### PR DESCRIPTION
# Description

- Adds checks to authenticate each authorization, to avoid scenarios where authorizations part-way through authentication would be superceded by other authorization requests. 
- Tweaks email dropdown placeholder to match Figma.
- Adds check to allow passthrough to Passport Settings after logging in to it. Now Passport Settings has the same session behavious as Console.

Closes #2059

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Log in to Passport Settings. Go to Passport root URL. Should pass you through to Passport settings.
- Initiate a authorization request (craft manually). Should prompt you for account to log in with, then present authz screen.
- In Passport Settings, initiate a connect account flow but don't complete it. Part way through, put in a (manually crafted) authz request in the URL. Should prompt you for login then present authz screen for the account selected.
- Test connect account flows from Passport Settings as well as from email dropdown in authz screen.
- Test email dropdown placeholder with account with connected email addresses, as well as one without any connected email addresses.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
