### PR TITLE
fix(passport): redirectURI matching without queryparams

### DIFF
--- a/apps/passport/app/utils/authenticate.server.ts
+++ b/apps/passport/app/utils/authenticate.server.ts
@@ -11,11 +11,6 @@ import {
   getAddressClient,
 } from '~/platform.server'
 import { createUserSession, parseJwt } from '~/session.server'
-import {
-  CryptoAddressType,
-  EmailAddressType,
-  OAuthAddressType,
-} from '@proofzero/types/address'
 import { generateGradient } from './gradient.server'
 import { redirect } from '@remix-run/cloudflare'
 import type { TraceSpan } from '@proofzero/platform-middleware/trace'
@@ -41,9 +36,7 @@ export const authenticateAddress = async (
       appData.redirectUri += '?error=ALREADY_CONNECTED'
     }
 
-    return redirect(
-      getRedirectURL(appData, existing ? `ALREADY_CONNECTED` : null)
-    )
+    return redirect(getRedirectURL(appData))
   }
 
   try {

--- a/apps/passport/app/utils/authorize.server.ts
+++ b/apps/passport/app/utils/authorize.server.ts
@@ -95,11 +95,18 @@ export function authzParamsMatch(
     authzCookieParams.scope.length === authzQueryParams.scope.length &&
     authzQueryParams.scope.every((e) => authzCookieParams.scope!.includes(e))
   )
+  const authzReqRedirectURL = authzQueryParams.redirectUri
+    ? new URL(authzQueryParams.redirectUri)
+    : undefined
+  const authzReqCookieRedirectURL = authzCookieParams.redirectUri
+    ? new URL(authzCookieParams.redirectUri)
+    : undefined
 
   return (
     scopesMatch &&
     authzCookieParams.clientId === authzQueryParams.clientId &&
-    authzCookieParams.redirectUri === authzQueryParams.redirectUri &&
+    `${authzReqRedirectURL?.origin}${authzReqRedirectURL?.pathname}` ===
+      `${authzReqCookieRedirectURL?.origin}${authzReqCookieRedirectURL?.pathname}` &&
     authzCookieParams.state === authzQueryParams.state
   )
 }


### PR DESCRIPTION
### Description

Fixes the way the redirect URI is compared between the authz query params and authz param cookie to exclude redirect URI query params. This was causing issue when an additional param of `error` was being added in the scenario when a connected account flow was attempted with an already connected account.
### Related Issues

- Closes #2078

### Testing

Log on to Passport settings and initiate a Connect account flow. Choose an account that's already connected elsewhere. You should be redirected to the Account screen and see the toast message with the error.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code
- [ ] I have updated the documentation (if necessary)
