### PR TITLE
feat(passport): apple email in dropdown

### DIFF
--- a/apps/passport/app/routes/authenticate/$clientId/index.tsx
+++ b/apps/passport/app/routes/authenticate/$clientId/index.tsx
@@ -12,15 +12,11 @@ import { useEffect, useState } from 'react'
 import { HiOutlineMail } from 'react-icons/hi'
 import { Authentication, ConnectButton } from '~/components'
 import ConnectOAuthButton from '~/components/connect-oauth-button'
-import {
-  ActionFunction,
-  redirect,
-  json,
-  LoaderFunction,
-} from '@remix-run/cloudflare'
+import { redirect, json } from '@remix-run/cloudflare'
 
 import AuthButton from '~/components/connect-button/AuthButton'
 import { getConsoleParams } from '~/session.server'
+import type { ActionFunction, LoaderFunction } from '@remix-run/cloudflare'
 
 export const loader: LoaderFunction = async ({ request, params }) => {
   const url = new URL(request.url)

--- a/apps/passport/app/routes/authorize.tsx
+++ b/apps/passport/app/routes/authorize.tsx
@@ -495,7 +495,7 @@ export default function Authorize() {
                                     qp.append('prompt', 'connect')
                                     qp.append(
                                       'login_hint',
-                                      'email microsoft google'
+                                      'email microsoft google apple'
                                     )
 
                                     return navigate(

--- a/apps/passport/wrangler.toml
+++ b/apps/passport/wrangler.toml
@@ -35,7 +35,7 @@ INTERNAL_GOOGLE_OAUTH_CALLBACK_URL = "http://localhost:10001/connect/google/call
 INTERNAL_GITHUB_OAUTH_CALLBACK_URL = "http://localhost:10001/connect/github/callback"
 INTERNAL_TWITTER_OAUTH_CALLBACK_URL = "http://localhost:10001/connect/twitter/callback"
 INTERNAL_MICROSOFT_OAUTH_CALLBACK_URL = "http://localhost:10001/connect/microsoft/callback"
-INTERNAL_APPLE_OAUTH_CALLBACK_URL = "http://localhost:10001/connect/appleid/callback"
+INTERNAL_APPLE_OAUTH_CALLBACK_URL = "http://localhost:10001/connect/apple/callback"
 INTERNAL_DISCORD_OAUTH_CALLBACK_URL = "http://localhost:10001/connect/discord/callback"
 INTERNAL_GOOGLE_ANALYTICS_TAG = "G-NHNH4KRWC3"
 

--- a/packages/design-system/src/atoms/email/EmailSelect.tsx
+++ b/packages/design-system/src/atoms/email/EmailSelect.tsx
@@ -7,7 +7,7 @@ import { HiCheck } from 'react-icons/hi'
 import { TbCircleOff, TbCirclePlus } from 'react-icons/tb'
 import { MdOutlineAlternateEmail } from 'react-icons/md'
 
-import { OAuthAddressType } from '@proofzero/types/address'
+import { EmailAddressType, OAuthAddressType } from '@proofzero/types/address'
 
 import googleIcon from '@proofzero/design-system/src/assets/social_icons/google.svg'
 import microsoftIcon from '@proofzero/design-system/src/assets/social_icons/microsoft.svg'
@@ -24,6 +24,20 @@ type EmailSelectProps = {
   onSelect?: (selected: EmailSelectListItem) => void
 }
 
+const getIconUrl = (
+  type?: OAuthAddressType | EmailAddressType | OptionType
+) => {
+  return type
+    ? type === OAuthAddressType.Microsoft
+      ? microsoftIcon
+      : type === OAuthAddressType.Apple
+      ? appleIcon
+      : type === OAuthAddressType.Google
+      ? googleIcon
+      : null
+    : null
+}
+
 export const EmailSelect = ({
   items,
   enableAddNew = false,
@@ -38,12 +52,7 @@ export const EmailSelect = ({
     }
   }, [selected])
 
-  const selectedIconURL =
-    selected?.type === OAuthAddressType.Microsoft
-      ? microsoftIcon
-      : selected?.type === OAuthAddressType.Google
-      ? googleIcon
-      : null
+  const selectedIconURL = getIconUrl(selected?.type)
 
   return (
     <Listbox
@@ -66,12 +75,6 @@ export const EmailSelect = ({
           >
             {selectedIconURL ? (
               <img src={selectedIconURL} className="w-4 h-4 mr-3" />
-            ) : selected?.type === OAuthAddressType.Apple ? (
-              <img src={appleIcon} className="w-4 h-4 mr-3" />
-            ) : selected?.type === OAuthAddressType.Microsoft ? (
-              <img src={microsoftIcon} className="w-4 h-4 mr-3" />
-            ) : selected?.type === OAuthAddressType.Google ? (
-              <img src={googleIcon} className="w-4 h-4 mr-3" />
             ) : (
               <MdOutlineAlternateEmail className="w-4 h-4 mr-3" />
             )}
@@ -110,13 +113,7 @@ export const EmailSelect = ({
              absolute w-full mt-1 bg-white"
             >
               {items.map((item, i) => {
-                const iconURL =
-                  item.type === OAuthAddressType.Microsoft
-                    ? microsoftIcon
-                    : item.type === OAuthAddressType.Google
-                    ? googleIcon
-                    : null
-
+                const iconURL = getIconUrl(item.type)
                 return (
                   <Listbox.Option
                     key={i}
@@ -128,8 +125,6 @@ export const EmailSelect = ({
                       <div className="flex flex-row items-center">
                         {iconURL ? (
                           <img src={iconURL} className="w-4 h-4 mr-3" />
-                        ) : item.type === OAuthAddressType.Apple ? (
-                          <img src={appleIcon} className="w-4 h-4 mr-3" />
                         ) : (
                           <MdOutlineAlternateEmail className="w-4 h-4 mr-3" />
                         )}

--- a/packages/design-system/src/atoms/email/EmailSelect.tsx
+++ b/packages/design-system/src/atoms/email/EmailSelect.tsx
@@ -11,7 +11,7 @@ import { OAuthAddressType } from '@proofzero/types/address'
 
 import googleIcon from '@proofzero/design-system/src/assets/social_icons/google.svg'
 import microsoftIcon from '@proofzero/design-system/src/assets/social_icons/microsoft.svg'
-import { AiFillApple } from 'react-icons/ai'
+import appleIcon from '@proofzero/design-system/src/assets/social_icons/apple.svg'
 
 import { OptionType } from '@proofzero/utils/getNormalisedConnectedEmails'
 
@@ -67,7 +67,7 @@ export const EmailSelect = ({
             {selectedIconURL ? (
               <img src={selectedIconURL} className="w-4 h-4 mr-3" />
             ) : selected?.type === OAuthAddressType.Apple ? (
-              <AiFillApple className="w-4 h-4 mr-3" />
+              <img src={appleIcon} className="w-4 h-4 mr-3" />
             ) : (
               <MdOutlineAlternateEmail className="w-4 h-4 mr-3" />
             )}
@@ -125,7 +125,7 @@ export const EmailSelect = ({
                         {iconURL ? (
                           <img src={iconURL} className="w-4 h-4 mr-3" />
                         ) : item.type === OAuthAddressType.Apple ? (
-                          <AiFillApple className="w-4 h-4 mr-3" />
+                          <img src={appleIcon} className="w-4 h-4 mr-3" />
                         ) : (
                           <MdOutlineAlternateEmail className="w-4 h-4 mr-3" />
                         )}

--- a/packages/design-system/src/atoms/email/EmailSelect.tsx
+++ b/packages/design-system/src/atoms/email/EmailSelect.tsx
@@ -68,6 +68,10 @@ export const EmailSelect = ({
               <img src={selectedIconURL} className="w-4 h-4 mr-3" />
             ) : selected?.type === OAuthAddressType.Apple ? (
               <img src={appleIcon} className="w-4 h-4 mr-3" />
+            ) : selected?.type === OAuthAddressType.Microsoft ? (
+              <img src={microsoftIcon} className="w-4 h-4 mr-3" />
+            ) : selected?.type === OAuthAddressType.Google ? (
+              <img src={googleIcon} className="w-4 h-4 mr-3" />
             ) : (
               <MdOutlineAlternateEmail className="w-4 h-4 mr-3" />
             )}

--- a/packages/design-system/src/atoms/email/EmailSelect.tsx
+++ b/packages/design-system/src/atoms/email/EmailSelect.tsx
@@ -11,6 +11,7 @@ import { OAuthAddressType } from '@proofzero/types/address'
 
 import googleIcon from '@proofzero/design-system/src/assets/social_icons/google.svg'
 import microsoftIcon from '@proofzero/design-system/src/assets/social_icons/microsoft.svg'
+import { AiFillApple } from 'react-icons/ai'
 
 import { OptionType } from '@proofzero/utils/getNormalisedConnectedEmails'
 
@@ -65,6 +66,8 @@ export const EmailSelect = ({
           >
             {selectedIconURL ? (
               <img src={selectedIconURL} className="w-4 h-4 mr-3" />
+            ) : selected?.type === OAuthAddressType.Apple ? (
+              <AiFillApple className="w-4 h-4 mr-3" />
             ) : (
               <MdOutlineAlternateEmail className="w-4 h-4 mr-3" />
             )}
@@ -121,6 +124,8 @@ export const EmailSelect = ({
                       <div className="flex flex-row items-center">
                         {iconURL ? (
                           <img src={iconURL} className="w-4 h-4 mr-3" />
+                        ) : item.type === OAuthAddressType.Apple ? (
+                          <AiFillApple className="w-4 h-4 mr-3" />
                         ) : (
                           <MdOutlineAlternateEmail className="w-4 h-4 mr-3" />
                         )}

--- a/packages/design-system/src/molecules/email-connection-modal/EmailConnection.tsx
+++ b/packages/design-system/src/molecules/email-connection-modal/EmailConnection.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react'
 import googleIcon from '@proofzero/design-system/src/assets/social_icons/google.svg'
 import microsoftIcon from '@proofzero/design-system/src/assets/social_icons/microsoft.svg'
+import { AiFillApple } from 'react-icons/ai'
 
 import { MdOutlineEmail } from 'react-icons/md'
 import { Text } from '../../atoms/text/Text'
@@ -16,6 +17,7 @@ export type EmailConnectionProp = {
     | EmailAddressType.Email
     | OAuthAddressType.Google
     | OAuthAddressType.Microsoft
+    | OAuthAddressType.Apple
   callback: () => void
 }
 
@@ -31,6 +33,7 @@ const iconMapper = {
   [OAuthAddressType.Microsoft]: (
     <img src={microsoftIcon} alt="microsoft" className="my-2" />
   ),
+  [OAuthAddressType.Apple]: <AiFillApple size={24} className="my-2" />,
   [EmailAddressType.Email]: <MdOutlineEmail size={24} className="my-2" />,
 }
 

--- a/packages/design-system/src/molecules/email-connection-modal/EmailConnection.tsx
+++ b/packages/design-system/src/molecules/email-connection-modal/EmailConnection.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
 import googleIcon from '@proofzero/design-system/src/assets/social_icons/google.svg'
 import microsoftIcon from '@proofzero/design-system/src/assets/social_icons/microsoft.svg'
-import { AiFillApple } from 'react-icons/ai'
+import appleIcon from '@proofzero/design-system/src/assets/social_icons/apple.svg'
 
 import { MdOutlineEmail } from 'react-icons/md'
 import { Text } from '../../atoms/text/Text'
@@ -33,7 +33,9 @@ const iconMapper = {
   [OAuthAddressType.Microsoft]: (
     <img src={microsoftIcon} alt="microsoft" className="my-2" />
   ),
-  [OAuthAddressType.Apple]: <AiFillApple size={24} className="my-2" />,
+  [OAuthAddressType.Apple]: (
+    <img src={appleIcon} alt="microsoft" className="my-2" />
+  ),
   [EmailAddressType.Email]: <MdOutlineEmail size={24} className="my-2" />,
 }
 

--- a/packages/security/persona.ts
+++ b/packages/security/persona.ts
@@ -49,6 +49,7 @@ export async function validatePersonaData(
       if (
         addressProfile.type !== OAuthAddressType.Google &&
         addressProfile.type !== OAuthAddressType.Microsoft &&
+        addressProfile.type !== OAuthAddressType.Apple &&
         addressProfile.type !== EmailAddressType.Email
       )
         throw new BadRequestError({

--- a/packages/utils/getNormalisedConnectedEmails.ts
+++ b/packages/utils/getNormalisedConnectedEmails.ts
@@ -34,29 +34,8 @@ export default function (
       )
     })
     .map((address) => {
-      if (address.rc.node_type === NodeType.OAuth) {
-        if (address.rc.addr_type === OAuthAddressType.Google)
-          return {
-            type: OAuthAddressType.Google,
-            email: address.qc.alias,
-            addressURN: address.baseUrn as AddressURN,
-          }
-        if (address.rc.addr_type === OAuthAddressType.Apple)
-          return {
-            type: OAuthAddressType.Apple,
-            email: address.qc.alias,
-            addressURN: address.baseUrn as AddressURN,
-          }
-        if (address.rc.addr_type === OAuthAddressType.Microsoft)
-          return {
-            type: OAuthAddressType.Microsoft,
-            email: address.qc.alias,
-            addressURN: address.baseUrn as AddressURN,
-          }
-      }
-
       return {
-        type: EmailAddressType.Email,
+        type: address.rc.addr_type as OAuthAddressType | EmailAddressType,
         email: address.qc.alias,
         addressURN: address.baseUrn as AddressURN,
       }

--- a/packages/utils/getNormalisedConnectedEmails.ts
+++ b/packages/utils/getNormalisedConnectedEmails.ts
@@ -27,7 +27,8 @@ export default function (
       return (
         (address.rc.node_type === NodeType.OAuth &&
           (address.rc.addr_type === OAuthAddressType.Google ||
-            address.rc.addr_type === OAuthAddressType.Microsoft)) ||
+            address.rc.addr_type === OAuthAddressType.Microsoft ||
+            address.rc.addr_type === OAuthAddressType.Apple)) ||
         (address.rc.node_type === NodeType.Email &&
           address.rc.addr_type === EmailAddressType.Email)
       )
@@ -37,6 +38,12 @@ export default function (
         if (address.rc.addr_type === OAuthAddressType.Google)
           return {
             type: OAuthAddressType.Google,
+            email: address.qc.alias,
+            addressURN: address.baseUrn as AddressURN,
+          }
+        if (address.rc.addr_type === OAuthAddressType.Apple)
+          return {
+            type: OAuthAddressType.Apple,
             email: address.qc.alias,
             addressURN: address.baseUrn as AddressURN,
           }


### PR DESCRIPTION
### Description

Adds apple as an email provider in the email dropdown component

### Related Issues

- Closes #2087

### Testing

1. Setted up ngrok server that was forwarding to my passport local (to be able to login with apple)
2. Created new account with apple provider
3. went to `http://{ngrok-url}//authorize?client_id={client_id}&redirect_uri=http://localhost:10003&state=foo&scope=profile+email/`
4. This is the following: 

https://user-images.githubusercontent.com/33105890/231858225-9d7cdd1e-5c0d-4481-8da3-0f6a39d96c58.mov



### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code
- [ ] I have updated the documentation (if necessary)
