### PR TITLE
fix(address): keep the stored refresh token if not provided

### DIFF
--- a/platform/address/src/nodes/oauth.ts
+++ b/platform/address/src/nodes/oauth.ts
@@ -107,7 +107,7 @@ export default class OAuthAddress {
         ...data,
         timestamp: Date.now(),
         accessToken: body.access_token,
-        refreshToken: body.refresh_token,
+        refreshToken: body.refresh_token ?? data.refreshToken,
         extraParams: {
           ...data.extraParams,
           expires_in: body.expires_in,


### PR DESCRIPTION
---

### Description

The object in the response if does not have a refresh token then the property in
the stored object is removed.

This change puts the stored refresh token into the object if there is none in
the response.

### Related Issues

- Closes #2089

### Testing

- [x] Manual

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [ ] I have tested my code
- [x] I have updated the documentation (if necessary)