### PR TITLE
fix(passport): redirect uri validation

### DIFF
--- a/apps/passport/app/routes/authorize.tsx
+++ b/apps/passport/app/routes/authorize.tsx
@@ -156,9 +156,18 @@ export const loader: LoaderFunction = async ({ request, context }) => {
       }),
     ])
 
+    const providedUrl = new URL(redirectUri)
+    const configuredUrl = new URL(appPublicProps.redirectURI)
+
     if (!appPublicProps.scopes || !appPublicProps.scopes.length)
       throw new BadRequestError({
         message: 'No allowed scope was configured for the app',
+      })
+
+    if (providedUrl.hostname !== configuredUrl.hostname)
+      throw new BadRequestError({
+        message:
+          'Provided redirect URI did not match with configured redirect URI',
       })
 
     // We need a unique set of scopes to avoid duplicates

--- a/apps/passport/app/routes/authorize.tsx
+++ b/apps/passport/app/routes/authorize.tsx
@@ -156,15 +156,15 @@ export const loader: LoaderFunction = async ({ request, context }) => {
       }),
     ])
 
-    const providedUrl = new URL(redirectUri)
     const configuredUrl = new URL(appPublicProps.redirectURI)
+    const providedUrl = redirectUri ? new URL(redirectUri) : configuredUrl
 
     if (!appPublicProps.scopes || !appPublicProps.scopes.length)
       throw new BadRequestError({
         message: 'No allowed scope was configured for the app',
       })
 
-    if (providedUrl.hostname !== configuredUrl.hostname)
+    if (providedUrl.origin !== configuredUrl.origin)
       throw new BadRequestError({
         message:
           'Provided redirect URI did not match with configured redirect URI',

--- a/platform/starbase/src/jsonrpc/methods/getAppPublicProps.ts
+++ b/platform/starbase/src/jsonrpc/methods/getAppPublicProps.ts
@@ -22,10 +22,11 @@ export const getAppPublicProps = async ({
 
   if (appDetails && appDetails.app && appDetails.published) {
     return {
-      name: appDetails.app?.name,
-      iconURL: appDetails.app?.icon || '',
+      name: appDetails.app.name,
+      iconURL: appDetails.app.icon || '',
+      redirectURI: appDetails.app.redirectURI || '',
       //As app.scopes can be a Set<string>, the following works universally
-      scopes: Array.from(appDetails.app?.scopes || []),
+      scopes: Array.from(appDetails.app.scopes || []),
     }
   } else {
     throw new Error(

--- a/platform/starbase/src/jsonrpc/validators/app.ts
+++ b/platform/starbase/src/jsonrpc/validators/app.ts
@@ -46,6 +46,7 @@ export const AppPublicPropsSchema = z.object({
   name: z.string(),
   iconURL: z.string(),
   scopes: z.array(z.string()),
+  redirectURI: z.string(),
 })
 
 export type AppPublicProps = z.infer<typeof AppPublicPropsSchema>


### PR DESCRIPTION
### Description

Checks redirectURI on authorize screen with the one configured in console.

### Related Issues

- Closes #2060

### Testing

1. went to authorize screen with invalid redirect URL (different from the one that was set in console)
2. got an error
3. changed it so redirect URI in link matches with one in console
4. worked
5. went back to invalid redirect URI, updated it in console configurations so they match
6. reloaded page -> and it worked

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code
- [ ] I have updated the documentation (if necessary)
