### PR TITLE
fix(passport): truncate text for 'continue-with' button

### DIFF
--- a/apps/passport/app/components/connect-button/AuthButton.tsx
+++ b/apps/passport/app/components/connect-button/AuthButton.tsx
@@ -24,12 +24,16 @@ export default ({
   >
     <div className="flex flex-row items-center space-x-3 py-1.5">
       {Graphic && (
-        <div className="w-6 h-6 flex justify-center items-center overflow-hidden">
+        <div
+          className="min-w-6 min-h-6 w-6 h-6
+        flex justify-center items-center overflow-hidden
+        shrink-0"
+        >
           {Graphic}
         </div>
       )}
 
-      <Text weight="medium" className="text-gray-800">
+      <Text weight="medium" className="text-gray-800 truncate">
         {text}
       </Text>
 


### PR DESCRIPTION
### Description

Doesn't shrink pfp for continue with button. Also truncates text on overflow (text-ellipsis)

### Related Issues

- Closes #2106 

### Testing

Visual changes were tested in browser on localhost

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code
- [ ] I have updated the documentation (if necessary)
