### PR TITLE
fix(passport): Corrects Passport Settings redirection bug

### DIFF
--- a/apps/passport/app/routes/index.tsx
+++ b/apps/passport/app/routes/index.tsx
@@ -1,15 +1,5 @@
 import { redirect } from '@remix-run/cloudflare'
 import type { LoaderFunction } from '@remix-run/cloudflare'
-export const loader: LoaderFunction = async ({ request, params }) => {
-  const qp = new URLSearchParams()
-
-  const url = new URL(request.url)
-  const { protocol, host } = url
-
-  qp.append('client_id', 'passport')
-  qp.append('redirect_uri', `${protocol}//${host}/settings`)
-  qp.append('state', 'skip')
-  qp.append('scope', '')
-
-  return redirect(`/authorize?${qp.toString()}`)
+export const loader: LoaderFunction = async () => {
+  return redirect(`/settings`)
 }

--- a/apps/passport/app/routes/settings.tsx
+++ b/apps/passport/app/routes/settings.tsx
@@ -1,7 +1,11 @@
 import { Outlet, useLoaderData } from '@remix-run/react'
 
 import { json } from '@remix-run/cloudflare'
-import { getConsoleParams, getValidatedSessionContext } from '~/session.server'
+import {
+  getConsoleParams,
+  getDefaultConsoleParams,
+  getValidatedSessionContext,
+} from '~/session.server'
 import { Popover } from '@headlessui/react'
 import SideMenu from '~/components/SideMenu'
 import Header from '~/components/Header'
@@ -30,11 +34,11 @@ export const links: LinksFunction = () => [
 ]
 
 export const loader: LoaderFunction = async ({ request, context }) => {
-  const lastCP = await getConsoleParams(request, context.env)
+  const passportDefaultAuthzParams = getDefaultConsoleParams(request)
 
   const { jwt, accountUrn } = await getValidatedSessionContext(
     request,
-    lastCP,
+    passportDefaultAuthzParams,
     context.env,
     context.traceSpan
   )


### PR DESCRIPTION
### Description

Going to Passport Settings directly by entering the URL in the browser, after just being signed out of a third part app, would cause the "Continue with" screen to be shown to log into Passport with. This would only happen on the first visit to Passport Settings, but not for the subequent ones. This fixes that.

### Related Issues

- N/A

### Testing

While being logged on to Passport Settings, log on to Profile and sign out. Then go to Passport Settings from the URL bar.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code
- [ ] I have updated the documentation (if necessary)
