### PR TITLE
bug(passport): existing account error key

### DIFF
--- a/apps/passport/app/routes/connect/$address/sign.tsx
+++ b/apps/passport/app/routes/connect/$address/sign.tsx
@@ -81,7 +81,7 @@ export const action: ActionFunction = async ({ request, context, params }) => {
   })
 
   if (appData?.prompt === 'connect' && existing) {
-    return redirect(`${appData.redirectUri}?error=ALREADY_CONNECTED`)
+    return redirect(`${appData.redirectUri}?connect_result=ALREADY_CONNECTED`)
   }
 
   // TODO: handle the error case


### PR DESCRIPTION
### Description

Key for connect flow toast notifications is now `connect_result`. It was initially `error`. This is a fix for a forgotten case that still had `error` as key.

### Testing

#### Scenario
1. Go to passport
2. Connect with wallet
3. Go to connected accounts
4. Click on connect account
5. Select same wallet
6. Get redirected to connected accounts
~~7. No error message~~

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code
- [ ] I have updated the documentation (if necessary)
