### PR TITLE
fix(passport): Fixed issue with submitted personaData

### DIFF
--- a/apps/passport/app/routes/authorize.tsx
+++ b/apps/passport/app/routes/authorize.tsx
@@ -408,9 +408,9 @@ export default function Authorize() {
 
     let personaData = {}
     if (scopes.includes('email'))
-      personaData = { ...persona, email: selectedEmail?.addressURN }
+      personaData = { ...personaData, email: selectedEmail?.addressURN }
     if (scopes.includes('connected_addresses'))
-      personaData = { ...persona, connected_addresses: connectedAddresses }
+      personaData = { ...personaData, connected_addresses: connectedAddresses }
 
     form.append('personaData', JSON.stringify(personaData))
     submit(form, { method: 'post' })


### PR DESCRIPTION
### Description

The user-submission from the authorization screen (with both `email` and `connected_addresses` scope values) was overriding the object being sent with the `connected_addresses` property, overwriting the object that already had the submission for the `email` scope value.

### Related Issues

- Closes #2132

### Testing

Craft request with `email` and `connected_addresses` and ensure both claims are present in ID token.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code
- [x] I have updated the documentation (if necessary)
