### PR TITLE
fix(passport): Support submitting connected address selection to ALL

### DIFF
--- a/apps/passport/app/routes/authorize.tsx
+++ b/apps/passport/app/routes/authorize.tsx
@@ -40,7 +40,6 @@ import {
 } from '~/utils/authorize.server'
 import { useEffect, useState } from 'react'
 import { OptionType } from '@proofzero/utils/getNormalisedConnectedEmails'
-import { ToastType, toast } from '@proofzero/design-system/src/atoms/toast'
 import { Text } from '@proofzero/design-system'
 import { BadRequestError, InternalServerError } from '@proofzero/errors'
 import { JsonError } from '@proofzero/utils/errors'

--- a/packages/types/application.ts
+++ b/packages/types/application.ts
@@ -13,3 +13,11 @@ export type ClaimValue = z.infer<typeof ClaimValue>
 
 export const PersonaData = z.record(ClaimName, ClaimValue)
 export type PersonaData = z.infer<typeof PersonaData>
+
+export enum AuthorizationControlSelection {
+  ALL,
+  NONE,
+}
+export const AuthorizationControlSelectionEnum = z.nativeEnum(
+  AuthorizationControlSelection
+)

--- a/platform/access/src/jsonrpc/methods/exchangeToken.ts
+++ b/platform/access/src/jsonrpc/methods/exchangeToken.ts
@@ -221,7 +221,7 @@ const handleAuthorizationCode: ExchangeTokenMethod<
     account,
     clientId,
     scope,
-    { edgesFetcher: ctx.Edges },
+    { edgesFetcher: ctx.Edges, accountFetcher: ctx.Account },
     ctx.traceSpan,
     personaData
   )

--- a/platform/access/src/jsonrpc/methods/getUserInfo.ts
+++ b/platform/access/src/jsonrpc/methods/getUserInfo.ts
@@ -50,6 +50,7 @@ export const getUserInfoMethod = async ({
     scope,
     {
       edgesFetcher: ctx.Edges,
+      accountFetcher: ctx.Account,
     },
     ctx.traceSpan,
     personaData


### PR DESCRIPTION
### Description

Backend now supports submitting value of `AuthorizationControlSelect.ALL` for the `connected_addresses` property of `personaData`. 

### Related Issues

- Closes #2129

### Testing

1. Locally forced value of `connected_addresses` to be `AuthorizationControlSelection.ALL` in line 412 of authorize.tsx.
2. Crafted `/authorize` call with `connected_addresses` scope value and exchanged resulting code for access token. Verified response from `/userinfo` with given access token contained all addresses.
3. Added a new connected address and repeated the `/userinfo` verification in step 2. Disconnected an address and repeated the same.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code
- [x] I have updated the documentation (if necessary)
