### PR TITLE
chore(passport): Unify tag naming for node references

### DIFF
--- a/packages/security/persona.ts
+++ b/packages/security/persona.ts
@@ -18,13 +18,9 @@ import {
 } from '@proofzero/errors'
 import { EmailAddressType, OAuthAddressType } from '@proofzero/types/address'
 import { PersonaData } from '@proofzero/types/application'
-import { SCOPES, SCOPES_JSON } from './scopes'
-import { Scopes } from '@proofzero/platform-middleware/scopes'
-import account from '@proofzero/platform-clients/account'
-import { MakeEdgeParams } from '@proofzero/platform/edges/src/jsonrpc/methods/makeEdge'
 import { AnyURN } from '@proofzero/urns'
 
-export const EDGE_AUTHORIZES_REF_TO: EdgeURN = EdgeSpace.urn('authorizes/refTo')
+export const EDGE_HAS_REFERENCE_TO: EdgeURN = EdgeSpace.urn('has/refTo')
 
 export async function validatePersonaData(
   accountUrn: AccountURN,
@@ -144,7 +140,7 @@ export async function setPersonaReferences(
 
   //Get existing references
   const edgesToDelete = await edgesClient.getEdges.query({
-    query: { tag: EDGE_AUTHORIZES_REF_TO, src: { baseUrn: accessNode } },
+    query: { tag: EDGE_HAS_REFERENCE_TO, src: { baseUrn: accessNode } },
   })
 
   //Delete existing references
@@ -163,7 +159,7 @@ export async function setPersonaReferences(
       //This returns promises that get awaited collectively above
       return edgesClient.makeEdge.mutate({
         src: accessNode,
-        tag: EDGE_AUTHORIZES_REF_TO,
+        tag: EDGE_HAS_REFERENCE_TO,
         dst: refUrn,
       })
     })
@@ -218,7 +214,7 @@ export async function getClaimValues(
         query: {
           src: { baseUrn: accessUrn },
           dst: { baseUrn: emailAddressUrn },
-          tag: EDGE_AUTHORIZES_REF_TO,
+          tag: EDGE_HAS_REFERENCE_TO,
         },
       })
       const emailAddress = edgesResults.edges[0].dst.qc.alias


### PR DESCRIPTION
### Description

Creates a unified Edge tag for nodes referencing other nodes. This will now be shared for personaData references as well as references to nodes in Console (eg. #1915)

### Related Issues

N/A

### Testing

N/A

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code
- [x] I have updated the documentation (if necessary)
