### PR TITLE
fix(access): Remove JSON.parse from env var retrieval.

### DIFF
--- a/platform/access/src/jwk.ts
+++ b/platform/access/src/jwk.ts
@@ -12,7 +12,7 @@ type JWKS = Array<Pair>
 export const getPrivateJWK = (context: Context): JWK => {
   try {
     const pairs: JWKS = JSON.parse(context.SECRET_JWKS)
-    const currentKid: string = JSON.parse(context.SECRET_JWK_CURRENT_KID)
+    const currentKid: string = context.SECRET_JWK_CURRENT_KID
     for (const pair of pairs) {
       if (pair.privateKey.kid === currentKid) {
         return pair.privateKey


### PR DESCRIPTION
### Description

Removes JSON parsing from retrieval of env var value for SECRET_JWK_CURRENT_KID

### Related Issues

N/A

### Testing

Manual deploy to dev and log in to passport.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
