### PR TITLE
chore(passport) Rename `alias` to `identifier` in `connected_accounts` scope response.

### DIFF
--- a/docs/reference/passport-api.md
+++ b/docs/reference/passport-api.md
@@ -108,15 +108,15 @@ Call this method to retrieve basic identity information for the user.
     connected_accounts: [
       {
         type: 'eth',
-        alias: '(eth address)'
+        identifier: '(eth address)'
       },
       {
         type: 'email',
-        alias: '(email address of connected account)'
+        identifier: '(email address of connected account)'
       },
       {
         type: 'github',
-        alias: '(github username)'
+        identifier: '(github username)'
       }
       //other addresses
     ]

--- a/packages/security/persona.ts
+++ b/packages/security/persona.ts
@@ -259,7 +259,7 @@ export async function getClaimValues(
           })) || []
 
         const claimResults = accountAddresses.map((a) => {
-          return { type: a.rc.addr_type, alias: a.qc.alias }
+          return { type: a.rc.addr_type, identifier: a.qc.alias }
         })
         result = { ...result, connected_accounts: claimResults }
       } else {


### PR DESCRIPTION
### Description

NOTE: This is a breaking change for the `connected_accounts` scope response schema. 

Rename `alias` to `identifier` in `connected_accounts` scope response.

Update docs to reflect the same.

### Related Issues

- Closes #2161

### Testing

Created new authorization request containing `connected_accounts` scope, and authorized all addresses. Checked ID token and content of `/userinfo` endpoint to verify new name for the property (`identifier`, not `alias`)

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [x] I have updated the documentation (if necessary)
