### PR TITLE
fix(passport): If name of email is the same for two types of email addresses they both look selected

### DIFF
--- a/packages/design-system/src/atoms/email/EmailSelect.stories.tsx
+++ b/packages/design-system/src/atoms/email/EmailSelect.stories.tsx
@@ -2,24 +2,33 @@ import React from 'react'
 import { EmailSelect } from './EmailSelect'
 
 import { OAuthAddressType, EmailAddressType } from '@proofzero/types/address'
+import { EmailSelectListItem } from '@proofzero/utils/getNormalisedConnectedEmails'
 
 export default {
   title: 'Atoms/Email/Select',
   component: EmailSelect,
 }
 
-const listItems = [
+const listItems: EmailSelectListItem[] = [
   {
     type: OAuthAddressType.Google,
     email: 'email@gmail.com',
+    addressURN: 'urn:rollupid:address/1',
   },
   {
     type: OAuthAddressType.Microsoft,
     email: 'email@microsoft.com',
+    addressURN: 'urn:rollupid:address/2',
   },
   {
     type: EmailAddressType.Email,
     email: 'email@yahoo.com',
+    addressURN: 'urn:rollupid:address/3',
+  },
+  {
+    type: EmailAddressType.Email,
+    email: 'email@gmail.com',
+    addressURN: 'urn:rollupid:address/4',
   },
 ]
 

--- a/packages/design-system/src/atoms/email/EmailSelect.tsx
+++ b/packages/design-system/src/atoms/email/EmailSelect.tsx
@@ -71,7 +71,7 @@ export const EmailSelect = ({
       onChange={(selected) => {
         setSelected(selected)
       }}
-      by="email"
+      by="addressURN"
     >
       {({ open }) => (
         <div className="relative bg-white">
@@ -143,7 +143,9 @@ export const EmailSelect = ({
                         <Text
                           size="sm"
                           weight={selected ? 'semibold' : 'normal'}
-                          className={`truncate text-ellipsis ${selected ? '' : ''} flex-1`}
+                          className={`truncate text-ellipsis ${
+                            selected ? '' : ''
+                          } flex-1`}
                         >
                           {item.email}
                         </Text>


### PR DESCRIPTION
### Description

- [x] Updated email-select item identifier from `email` to `id` (address urn)

### Related Issues

- Closes #2107 

### Testing

- [x] Added duplicate e-mail in storybook props
- [x] Reproduced condition in storybook
- [x] Updated item identifier
- [x] Condition no longer reproduces

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
