### PR TITLE
chore(console): twitter pixel

### DIFF
--- a/apps/console/app/entry.server.tsx
+++ b/apps/console/app/entry.server.tsx
@@ -43,6 +43,7 @@ export default function handleRequest(
             SELF,
             '*.google-analytics.com',
             'https://upload.imagedelivery.net',
+            'https://static.ads-twitter.com/uwt.js',
             // Used for Remix WebSocket Live Reaload
             ...(dev ? ['ws://localhost:*/socket'] : []),
           ],

--- a/apps/console/app/root.tsx
+++ b/apps/console/app/root.tsx
@@ -197,7 +197,7 @@ export default function App() {
             __html: `!function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
             },s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='https://static.ads-twitter.com/uwt.js',
             a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
-            twq('config','oe6lg');`, // TODO: make env var?
+            twq('config','oe6lg');twq('event', 'tw-oe6lg-oem1e', {});`, // TODO: make env var?
           }}
         />
 

--- a/apps/console/app/root.tsx
+++ b/apps/console/app/root.tsx
@@ -191,12 +191,13 @@ export default function App() {
           }}
         />
         <script
+          async
           nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `!function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
             },s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='https://static.ads-twitter.com/uwt.js',
             a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
-            twq('config','oe6lg');`,
+            twq('config','oe6lg');`, // TODO: make env var?
           }}
         />
 

--- a/apps/console/app/root.tsx
+++ b/apps/console/app/root.tsx
@@ -190,6 +190,16 @@ export default function App() {
             )}`,
           }}
         />
+        <script
+          nonce={nonce}
+          dangerouslySetInnerHTML={{
+            __html: `!function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
+            },s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='https://static.ads-twitter.com/uwt.js',
+            a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
+            twq('config','oe6lg');`,
+          }}
+        />
+
         <Scripts nonce={nonce} />
         <LiveReload nonce={nonce} />
       </body>


### PR DESCRIPTION
TODO:

- [ ] Only add this to elements of your website where you want to track customer actions (e.g. a thank you page, or "download" button). The Twitter pixel must be installed on any web pages where you want to track conversion events prior to adding event code. After installing the event code, confirm that the code has been successfully installed using [Twitter Pixel Helper](https://chrome.google.com/webstore/detail/twitter-pixel-helper/jepminnlebllinfmkhfbkpckogoiefpd). If using event parameters, make sure to update default values when you install the event code on your website.