### PR TITLE
fix(passport): reconnect result message and restore search parameters

### DIFF
--- a/apps/passport/app/routes/authenticate/$clientId/index.tsx
+++ b/apps/passport/app/routes/authenticate/$clientId/index.tsx
@@ -76,6 +76,7 @@ export const loader: LoaderFunction = async ({ request, params, context }) => {
     {
       clientId: params.clientId,
       displayDict,
+      loginHint,
     },
     {
       headers: {
@@ -117,7 +118,7 @@ export default () => {
     prompt?: string
   }>()
 
-  const { clientId, displayDict } = useLoaderData()
+  const { clientId, displayDict, loginHint } = useLoaderData()
 
   const [signData, setSignData] = useState<{
     nonce: string | undefined
@@ -148,12 +149,17 @@ export default () => {
 
   useEffect(() => {
     const url = new URL(window.location.href)
-    const error = url.searchParams.get('oauth_error')
-    if (!error) return
-    const message = getOAuthErrorMessage(error)
-    toast(ToastType.Error, { message }, { duration: 2000 })
 
-    url.searchParams.delete('oauth_error')
+    if (prompt) url.searchParams.set('prompt', prompt)
+    if (loginHint) url.searchParams.set('login_hint', loginHint)
+
+    const error = url.searchParams.get('oauth_error')
+    if (error) {
+      const message = getOAuthErrorMessage(error)
+      toast(ToastType.Error, { message }, { duration: 2000 })
+      url.searchParams.delete('oauth_error')
+    }
+
     history.replaceState(null, '', url.toString())
   })
 

--- a/apps/passport/app/session.server.ts
+++ b/apps/passport/app/session.server.ts
@@ -35,7 +35,6 @@ const getAuthenticationParamsSessionStorage = (env: Env) => {
       path: '/',
       sameSite: 'lax',
       secure: process.env.NODE_ENV == 'production',
-      maxAge: 10,
       httpOnly: true,
       secrets: [env.SECRET_SESSION_SALT],
     },

--- a/apps/passport/app/utils/authenticate.server.ts
+++ b/apps/passport/app/utils/authenticate.server.ts
@@ -48,7 +48,7 @@ export const authenticateAddress = async (
   if (['connect', 'reconnect'].includes(appData?.prompt)) {
     const redirectURL = getRedirectURL(
       appData,
-      existing ? 'ALREADY_CONNECTED' : undefined
+      existing && appData.prompt === 'connect' ? 'ALREADY_CONNECTED' : undefined
     )
 
     return redirect(redirectURL, {


### PR DESCRIPTION
### Description

- `ALREADY_CONNECTED` result is only valid if `prompt=connect`
- `prompt` and `login_hint` search parameters restored
- authentication parameters cookie is a session cookie now

### Related Issues

- Closes #2180

### Testing

- Manual

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [x] I have updated the documentation (if necessary)