### PR TITLE
feat(platform): Logbridge - centralized log management

### DIFF
--- a/.github/workflows/main-logbridge.yaml
+++ b/.github/workflows/main-logbridge.yaml
@@ -1,0 +1,57 @@
+name: Logbridge
+
+on:
+  push:
+    branches:
+      - main
+
+defaults:
+  run:
+    working-directory: platform/logbridge
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: cachix/install-nix-action@v18
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - run: nix-build ../platform.nix
+
+      - name: Cache Dependencies
+        id: cache-modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            .yarn
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-
+
+      - name: Install Dependencies
+        run: yarn install
+
+      - name: Test
+        run: yarn run test
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@2.0.0
+        with:
+          apiToken: ${{ secrets.TOKEN_CLOUDFLARE_API }}
+          accountId: ${{ secrets.INTERNAL_CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: platform/logbridge
+          command: publish
+          secrets: |
+            INTERNAL_LOKI_USER
+            SECRET_LOKI_API_KEY
+            INTERNAL_LOKI_URL
+            SECRET_LOGPUSH_JOB_AUTHZ_KEY
+        env:
+          INTERNAL_LOKI_USER: ${{ secrets.INTERNAL_LOKI_USER }}
+          SECRET_LOKI_API_KEY: ${{ secrets.SECRET_LOKI_API_KEY }}
+          INTERNAL_LOKI_URL: ${{ secrets.INTERNAL_LOKI_URL }}
+          SECRET_LOGPUSH_JOB_AUTHZ_KEY: ${{ secrets.SECRET_LOGPUSH_JOB_AUTHZ_KEY }}

--- a/apps/console/server.ts
+++ b/apps/console/server.ts
@@ -40,13 +40,15 @@ const handleEvent = async (event: FetchEvent) => {
     const newEvent = Object.assign(event, { traceSpan: newTraceSpan })
 
     console.debug(
-      `Started HTTP handler for ${reqURL.pathname}/${reqURL.searchParams} span: ${newTraceSpan}`
+      `Started HTTP handler for ${reqURL.pathname}/${reqURL.searchParams}`,
+      newTraceSpan.toString()
     )
     try {
       response = await requestHandler(newEvent)
     } finally {
       console.debug(
-        `Completed HTTP handler for ${reqURL.pathname}/${reqURL.searchParams} span: ${newTraceSpan}`
+        `Completed HTTP handler for ${reqURL.pathname}/${reqURL.searchParams}`,
+        newTraceSpan.toString()
       )
     }
   }

--- a/apps/console/wrangler.toml
+++ b/apps/console/wrangler.toml
@@ -5,13 +5,14 @@ name = "console"
 workers_dev = false
 main = "./build/index.js"
 compatibility_date = "2022-04-05"
-compatibility_flags = [ "streams_enable_constructors" ]
+compatibility_flags = ["streams_enable_constructors"]
+logpush = true
 
 
 services = [
-  { binding = "Starbase", service = "starbase"},
+  { binding = "Starbase", service = "starbase" },
   { binding = "Images", service = "images" },
-  { binding = "Account", service = "account"}
+  { binding = "Account", service = "account" },
 ]
 
 # development
@@ -31,7 +32,7 @@ local_protocol = "http"
 [vars]
 DEPLOY_ENV = "local"
 PASSPORT_URL = "http://localhost:10001"
-STORAGE_NAMESPACE="console"
+STORAGE_NAMESPACE = "console"
 INTERNAL_GOOGLE_ANALYTICS_TAG = "G-NHNH4KRWC3"
 PROFILE_APP_URL = "http://localhost:10003"
 COOKIE_DOMAIN = "localhost"
@@ -40,25 +41,24 @@ COOKIE_DOMAIN = "localhost"
 # -----------------------------------------------------------------------------
 
 [site]
-  bucket = "./public"
+bucket = "./public"
 
 # Build
 # -----------------------------------------------------------------------------
 
 [build]
-  command = "yarn build -- --sourcemap"
+command = "yarn build -- --sourcemap"
 
 # Environment: dev
 # -----------------------------------------------------------------------------
 
 
-
 [env.dev]
 
 services = [
-  { binding = "Starbase", service = "starbase-dev"},
+  { binding = "Starbase", service = "starbase-dev" },
   { binding = "Images", service = "images-dev" },
-  { binding = "Account", service = "account-dev"}
+  { binding = "Account", service = "account-dev" },
 ]
 
 
@@ -74,7 +74,7 @@ routes = [
 DEPLOY_ENV = "dev"
 PASSPORT_URL = "https://passport-dev.rollup.id"
 COOKIE_DOMAIN = "rollup.id"
-STORAGE_NAMESPACE="console"
+STORAGE_NAMESPACE = "console"
 INTERNAL_GOOGLE_ANALYTICS_TAG = "G-NHNH4KRWC3"
 PROFILE_APP_URL = "https://my-dev.rollup.id"
 
@@ -84,9 +84,9 @@ PROFILE_APP_URL = "https://my-dev.rollup.id"
 [env.next]
 
 services = [
-  { binding = "Starbase", service = "starbase-next"},
+  { binding = "Starbase", service = "starbase-next" },
   { binding = "Images", service = "images-next" },
-  { binding = "Account", service = "account-next"}
+  { binding = "Account", service = "account-next" },
 ]
 
 # kv_namespaces = [
@@ -98,13 +98,13 @@ routes = [
 ]
 
 [env.next.build]
-  command = "yarn build"
+command = "yarn build"
 
 [env.next.vars]
 DEPLOY_ENV = "next"
 PASSPORT_URL = "https://passport-next.rollup.id"
 COOKIE_DOMAIN = "rollup.id"
-STORAGE_NAMESPACE="console"
+STORAGE_NAMESPACE = "console"
 INTERNAL_GOOGLE_ANALYTICS_TAG = "G-X7ZN16M4NB"
 PROFILE_APP_URL = "https://my-next.rollup.id"
 
@@ -116,7 +116,7 @@ PROFILE_APP_URL = "https://my-next.rollup.id"
 services = [
   { binding = "Starbase", service = "starbase-current", environment = "production" },
   { binding = "Images", service = "images-current" },
-  { binding = "Account", service = "account-current"}
+  { binding = "Account", service = "account-current" },
 ]
 
 # kv_namespaces = [
@@ -128,13 +128,13 @@ routes = [
 ]
 
 [env.current.build]
-  command = "yarn build"
+command = "yarn build"
 
 
 [env.current.vars]
 DEPLOY_ENV = "current"
 PASSPORT_URL = "https://passport.rollup.id"
 COOKIE_DOMAIN = "rollup.id"
-STORAGE_NAMESPACE="console"
+STORAGE_NAMESPACE = "console"
 INTERNAL_GOOGLE_ANALYTICS_TAG = "G-675VJMWSRY"
 PROFILE_APP_URL = "https://my.rollup.id"

--- a/apps/passport/server.ts
+++ b/apps/passport/server.ts
@@ -56,13 +56,15 @@ const handleEvent = async (event: FetchEvent) => {
     const newEvent = Object.assign(event, { traceSpan: newTraceSpan })
 
     console.debug(
-      `Started HTTP handler for ${reqURL.pathname}/${reqURL.searchParams} span: ${newTraceSpan}`
+      `Started HTTP handler for ${reqURL.pathname}/${reqURL.searchParams}`,
+      newTraceSpan.toString()
     )
     try {
       response = await requestHandler(newEvent)
     } finally {
       console.debug(
-        `Completed HTTP handler for ${reqURL.pathname}/${reqURL.searchParams} span ${newTraceSpan}`
+        `Completed HTTP handler for ${reqURL.pathname}/${reqURL.searchParams}`,
+        newTraceSpan.toString()
       )
     }
   }

--- a/apps/passport/wrangler.toml
+++ b/apps/passport/wrangler.toml
@@ -3,7 +3,8 @@ compatibility_date = "2022-04-05"
 main = "./build/index.js"
 name = "passport"
 workers_dev = false
-compatibility_flags = [ "streams_enable_constructors" ]
+compatibility_flags = ["streams_enable_constructors"]
+logpush = true
 
 # Services binding for local development
 services = [

--- a/apps/profile/app/helpers/clients.ts
+++ b/apps/profile/app/helpers/clients.ts
@@ -4,17 +4,19 @@ import { TRACEPARENT_HEADER_NAME } from '@proofzero/platform-middleware/trace'
 import { PlatformHeaders } from '@proofzero/platform-clients/base'
 
 export async function getGalaxyClient(reqHeaders: PlatformHeaders) {
-  const traceparent = reqHeaders ? reqHeaders[TRACEPARENT_HEADER_NAME] : ''
+  const traceparent = JSON.stringify({
+    traceparent: reqHeaders ? reqHeaders[TRACEPARENT_HEADER_NAME] : '',
+  })
   const gqlClient = new GraphQLClient('http://127.0.0.1', {
     // @ts-ignore
     fetch: Galaxy.fetch.bind(Galaxy),
     requestMiddleware: (r) => {
       r.headers = { ...reqHeaders, ...(r.headers as Record<string, string>) }
-      console.debug(`Starting GQL client request. Traceparent: ${traceparent}`)
+      console.debug(`Starting GQL client request.`, traceparent)
       return r
     },
     responseMiddleware(response) {
-      console.debug(`Completed GQL request. Traceparent: ${traceparent}`)
+      console.debug(`Completed GQL request.`, traceparent)
     },
   })
   return getSdk(gqlClient)

--- a/apps/profile/server.ts
+++ b/apps/profile/server.ts
@@ -37,13 +37,15 @@ const handleEvent = async (event: FetchEvent) => {
     //Have to force injection of new field so it is available in the context setup above
     const newEvent = Object.assign(event, { traceSpan: newTraceSpan })
     console.log(
-      `Started HTTP handler for ${reqURL.pathname}/${reqURL.searchParams} span: ${newTraceSpan}`
+      `Started HTTP handler for ${reqURL.pathname}/${reqURL.searchParams}`,
+      newTraceSpan.toString()
     )
     try {
       response = await requestHandler(newEvent)
     } finally {
       console.debug(
-        `Completed HTTP handler for ${reqURL.pathname}/${reqURL.searchParams} span: ${newTraceSpan}`
+        `Completed HTTP handler for ${reqURL.pathname}/${reqURL.searchParams}`,
+        newTraceSpan.toString()
       )
     }
   }

--- a/apps/profile/wrangler.toml
+++ b/apps/profile/wrangler.toml
@@ -6,6 +6,7 @@ main = "./build/index.js"
 name = "profile"
 
 workers_dev = false
+logpush = true
 
 # The default environment
 # ------------------------------------------------------------------------------
@@ -25,7 +26,7 @@ services = [
 ]
 
 kv_namespaces = [
-  { binding = "ProfileKV", id = "6510b0e703694f0388ced3de37df869d", preview_id = "b827cd51f02e4a569ed7b9ff2c680a75" }
+  { binding = "ProfileKV", id = "6510b0e703694f0388ced3de37df869d", preview_id = "b827cd51f02e4a569ed7b9ff2c680a75" },
 ]
 
 [vars]
@@ -40,8 +41,8 @@ DISCORD_URL = "https://discord.gg/rollupid"
 MINTPFP_CONTRACT_ADDRESS = "0x028aE75Bb01eef2A581172607b93af8D24F50643"
 INTERNAL_GOOGLE_ANALYTICS_TAG = "G-NHNH4KRWC3"
 PROFILE_VERSION = 1
-ALCHEMY_ETH_NETWORK="mainnet"
-ALCHEMY_POLYGON_NETWORK="mainnet"
+ALCHEMY_ETH_NETWORK = "mainnet"
+ALCHEMY_POLYGON_NETWORK = "mainnet"
 
 [site]
 bucket = "./public"
@@ -67,7 +68,7 @@ services = [
 
 ]
 kv_namespaces = [
-  { binding = "ProfileKV", id = "6510b0e703694f0388ced3de37df869d" }
+  { binding = "ProfileKV", id = "6510b0e703694f0388ced3de37df869d" },
 ]
 [env.dev.vars]
 
@@ -83,14 +84,14 @@ DISCORD_URL = "https://discord.gg/rollupid"
 MINTPFP_CONTRACT_ADDRESS = "0x028aE75Bb01eef2A581172607b93af8D24F50643"
 INTERNAL_GOOGLE_ANALYTICS_TAG = "G-NHNH4KRWC3"
 PROFILE_VERSION = 1
-ALCHEMY_ETH_NETWORK="mainnet"
-ALCHEMY_POLYGON_NETWORK="mainnet"
+ALCHEMY_ETH_NETWORK = "mainnet"
+ALCHEMY_POLYGON_NETWORK = "mainnet"
 
 # next (staging)
 # ------------------------------------------------------------------------------
 [env.next]
 routes = [
-    { pattern = "my-next.rollup.id", custom_domain = true, zone_name = "rollup.id" },
+  { pattern = "my-next.rollup.id", custom_domain = true, zone_name = "rollup.id" },
 ]
 services = [
   { binding = "Galaxy", service = "galaxy-next" },
@@ -99,7 +100,7 @@ services = [
 
 ]
 kv_namespaces = [
-  { binding = "ProfileKV", id = "451e189131d74dca87b41701555a839d" }
+  { binding = "ProfileKV", id = "451e189131d74dca87b41701555a839d" },
 ]
 [env.next.build]
 command = "yarn build"
@@ -118,8 +119,8 @@ DISCORD_URL = "https://discord.gg/rollupid"
 MINTPFP_CONTRACT_ADDRESS = "0x028aE75Bb01eef2A581172607b93af8D24F50643"
 INTERNAL_GOOGLE_ANALYTICS_TAG = "G-X7ZN16M4NB"
 PROFILE_VERSION = 1
-ALCHEMY_ETH_NETWORK="mainnet"
-ALCHEMY_POLYGON_NETWORK="mainnet"
+ALCHEMY_ETH_NETWORK = "mainnet"
+ALCHEMY_POLYGON_NETWORK = "mainnet"
 
 # current (production)
 # ------------------------------------------------------------------------------
@@ -133,8 +134,8 @@ services = [
   { binding = "Images", service = "images-current" },
 ]
 kv_namespaces = [
-  { binding = "ProfileKV", id = "3a5214b7dab24414a1cb65733a6143b2" }
-] 
+  { binding = "ProfileKV", id = "3a5214b7dab24414a1cb65733a6143b2" },
+]
 [env.current.build]
 command = "yarn build"
 
@@ -151,5 +152,5 @@ DISCORD_URL = "https://discord.gg/rollupid"
 MINTPFP_CONTRACT_ADDRESS = "0x3ebfaFE60F3Ac34f476B2f696Fc2779ff1B03193"
 INTERNAL_GOOGLE_ANALYTICS_TAG = "G-675VJMWSRY"
 PROFILE_VERSION = 1
-ALCHEMY_ETH_NETWORK="mainnet"
-ALCHEMY_POLYGON_NETWORK="mainnet"
+ALCHEMY_ETH_NETWORK = "mainnet"
+ALCHEMY_POLYGON_NETWORK = "mainnet"

--- a/packages/platform-clients/utils.ts
+++ b/packages/platform-clients/utils.ts
@@ -10,17 +10,19 @@ export const trpcClientLoggerGenerator = (
   headers?: Record<string, string>
 ): loggerFunction => {
   return (props) => {
+    const traceparent = JSON.stringify({
+      traceparent: headers ? headers[TRACEPARENT_HEADER_NAME] : '',
+    })
+
     if (props.direction === 'up')
       console.debug(
-        `Starting tRPC client call ${serviceName} ${props.path} call ${
-          props.id
-        } traceparent: ${headers ? headers[TRACEPARENT_HEADER_NAME] : 'None'}`
+        `Starting tRPC client call ${serviceName} ${props.path} call ${props.id}`,
+        traceparent
       )
     else
       console.debug(
-        `Completed tRPC client call ${serviceName} ${props.path} call ${
-          props.id
-        } traceparent ${headers ? headers[TRACEPARENT_HEADER_NAME] : 'None'}`
+        `Completed tRPC client call ${serviceName} ${props.path} call ${props.id}`,
+        traceparent
       )
   }
 }

--- a/packages/platform-middleware/log.ts
+++ b/packages/platform-middleware/log.ts
@@ -8,11 +8,13 @@ export const LogUsage: BaseMiddlewareFunction<BaseContext> = async ({
   ctx,
 }) => {
   console.debug(
-    `Starting tRPC handler for ${type} ${path} span: ${ctx.traceSpan}`
+    `Starting tRPC handler for ${type} ${path}`,
+    ctx.traceSpan?.toString()
   )
   const result = await next()
   console.debug(
-    `Completed tRPC handler for ${type} ${path} span: ${ctx.traceSpan}`
+    `Completed tRPC handler for ${type} ${path}`,
+    ctx.traceSpan?.toString()
   )
   return result
 }

--- a/packages/platform-middleware/trace.ts
+++ b/packages/platform-middleware/trace.ts
@@ -28,8 +28,11 @@ export class TraceSpan {
   }
 
   toString() {
-    const parentSegment = this.parentId ? `, parentId: ${this.parentId}` : ''
-    return `{ traceId: ${this.traceId}, spanId: ${this.spanId}${parentSegment}, duration: ${this.currendDuration} }`
+    const parentSegment = this.parentId ? `-${this.parentId}` : ''
+    return JSON.stringify({
+      tracespan: `${this.traceId}${parentSegment}-${this.spanId}${parentSegment}`,
+      duration: this.currendDuration,
+    })
   }
 }
 

--- a/platform/access/wrangler.toml
+++ b/platform/access/wrangler.toml
@@ -3,6 +3,7 @@ main = "src/index.ts"
 compatibility_date = "2022-10-26"
 node_compat = true
 workers_dev = false
+logpush = true
 
 durable_objects.bindings = [
   { name = "Access", class_name = "Access" },

--- a/platform/account/wrangler.toml
+++ b/platform/account/wrangler.toml
@@ -3,6 +3,7 @@ main = "src/index.ts"
 compatibility_date = "2022-10-26"
 node_compat = true
 workers_dev = false
+logpush = true
 
 durable_objects.bindings = [{ name = "Account", class_name = "Account" }]
 services = [{ binding = "Edges", service = "edges" }]
@@ -19,9 +20,7 @@ analytics_engine_datasets = [
   { binding = "Analytics", dataset = "PlatformAnalytics" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [dev]
 port = 10201
@@ -36,9 +35,7 @@ analytics_engine_datasets = [
   { binding = "Analytics", dataset = "PlatformAnalyticsDev" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [env.next]
 durable_objects.bindings = [{ name = "Account", class_name = "Account" }]
@@ -48,9 +45,7 @@ analytics_engine_datasets = [
   { binding = "Analytics", dataset = "PlatformAnalyticsNext" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [env.current]
 durable_objects.bindings = [{ name = "Account", class_name = "Account" }]
@@ -60,6 +55,4 @@ analytics_engine_datasets = [
   { binding = "Analytics", dataset = "PlatformAnalyticsCurrent" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]

--- a/platform/address/src/nodes/oauth.ts
+++ b/platform/address/src/nodes/oauth.ts
@@ -41,12 +41,12 @@ export default class OAuthAddress {
         headers: await this.getRequestHeaders(),
       })
       if (!response.ok) {
-        console.error(await response.text())
-        throw new Error('an error occurred')
+        console.warn('Could not fetch upstream profile', await response.text())
+        return
       }
       return response.json()
     } catch (err) {
-      console.error(err)
+      console.error('Error encountered with fetching profile', err)
     }
   }
 

--- a/platform/address/wrangler.toml
+++ b/platform/address/wrangler.toml
@@ -3,6 +3,7 @@ main = "src/index.ts"
 compatibility_date = "2022-10-26"
 node_compat = true
 workers_dev = false
+logpush = true
 
 durable_objects.bindings = [{ name = "Address", class_name = "Address" }]
 

--- a/platform/edges/wrangler.toml
+++ b/platform/edges/wrangler.toml
@@ -2,6 +2,7 @@ name = "edges"
 main = "src/index.ts"
 compatibility_date = "2022-11-24"
 node_compat = true
+logpush = true
 
 
 # #############################################################################
@@ -31,9 +32,7 @@ migrations_dir = "migrations"
 # Required secrets:
 # N/A
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 # Environment
 # -----------------------------------------------------------------------------
@@ -50,31 +49,27 @@ inspector_port = 11501
 local_protocol = "http"
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalytics"  },
+  { binding = "Analytics", dataset = "PlatformAnalytics" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 # Environment: dev
 # -----------------------------------------------------------------------------
 
 [env.dev]
 d1_databases = [
-  { binding = "EDGES", database_name = "edges-dev", database_id = "d5dc9f97-0f8e-4af7-90dd-cb84e44309bd", migrations_dir = "migrations" }
+  { binding = "EDGES", database_name = "edges-dev", database_id = "d5dc9f97-0f8e-4af7-90dd-cb84e44309bd", migrations_dir = "migrations" },
 ]
 
 [env.dev.vars]
 ENVIRONMENT = "dev"
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalyticsDev"  },
+  { binding = "Analytics", dataset = "PlatformAnalyticsDev" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 # Environment: next
 # -----------------------------------------------------------------------------
@@ -82,16 +77,14 @@ unsafe.bindings = [
 [env.next]
 
 d1_databases = [
-  { binding = "EDGES", database_name = "edges-next", database_id = "35573801-81b5-4c57-8a79-286343476d98", migrations_dir = "migrations" }
+  { binding = "EDGES", database_name = "edges-next", database_id = "35573801-81b5-4c57-8a79-286343476d98", migrations_dir = "migrations" },
 ]
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalyticsNext"  },
+  { binding = "Analytics", dataset = "PlatformAnalyticsNext" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [env.next.vars]
 ENVIRONMENT = "next"
@@ -102,16 +95,14 @@ ENVIRONMENT = "next"
 [env.current]
 
 d1_databases = [
-  { binding = "EDGES", database_name = "edges-current", database_id = "27b77920-664e-4e52-84ca-72be96b9a3fd", migrations_dir = "migrations" }
+  { binding = "EDGES", database_name = "edges-current", database_id = "27b77920-664e-4e52-84ca-72be96b9a3fd", migrations_dir = "migrations" },
 ]
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalyticsCurrent"  },
+  { binding = "Analytics", dataset = "PlatformAnalyticsCurrent" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [env.current.vars]
 ENVIRONMENT = "current"

--- a/platform/email/wrangler.toml
+++ b/platform/email/wrangler.toml
@@ -4,10 +4,9 @@ main = "src/index.ts"
 compatibility_date = "2022-10-05"
 
 workers_dev = false
+logpush = true
 
-services = [
-  { binding = "Test", service = "test" },
-]
+services = [{ binding = "Test", service = "test" }]
 
 [dev]
 port = 10105

--- a/platform/galaxy/src/index.ts
+++ b/platform/galaxy/src/index.ts
@@ -26,13 +26,13 @@ export default {
     ctx: ExecutionContext
   ): Promise<Response> {
     const traceSpan = generateTraceSpan(request.headers)
-    console.debug('Starting GQL handler, trace span: ', traceSpan.toString())
+    console.debug('Starting GQL handler', traceSpan.toString())
     const result = (await yoga.handleRequest(request, {
       env,
       ctx,
       traceSpan,
     })) as Response
-    console.debug('Completed GQL handler, trace span: ', traceSpan.toString())
+    console.debug('Completed GQL handler', traceSpan.toString())
     return result
   },
 }

--- a/platform/galaxy/wrangler.toml
+++ b/platform/galaxy/wrangler.toml
@@ -4,18 +4,17 @@ main = "src/index.ts"
 compatibility_date = "2022-10-19"
 node_compat = true
 wrangler_dev = false
+logpush = true
 
 # Services binding for local development
 services = [
   { binding = "Account", service = "account" },
   { binding = "Access", service = "access" },
   { binding = "Address", service = "address" },
-  { binding = "Starbase", service = "starbase"},
+  { binding = "Starbase", service = "starbase" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [dev]
 port = 10401
@@ -23,12 +22,10 @@ inspector_port = 11401
 local_protocol = "http"
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalytics"  },
+  { binding = "Analytics", dataset = "PlatformAnalytics" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 
 [env.dev]
@@ -41,12 +38,10 @@ services = [
 ]
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalyticsDev"  },
+  { binding = "Analytics", dataset = "PlatformAnalyticsDev" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [env.next]
 route = { pattern = "galaxy-next.rollup.id", custom_domain = true, zone_name = "rollup.id" }
@@ -58,12 +53,10 @@ services = [
 ]
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalyticsNext"  },
+  { binding = "Analytics", dataset = "PlatformAnalyticsNext" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [env.current]
 route = { pattern = "galaxy.rollup.id", custom_domain = true, zone_name = "rollup.id" }
@@ -75,9 +68,7 @@ services = [
 ]
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalyticsCurrent"  },
+  { binding = "Analytics", dataset = "PlatformAnalyticsCurrent" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]

--- a/platform/images/wrangler.toml
+++ b/platform/images/wrangler.toml
@@ -7,7 +7,8 @@ compatibility_date = "2022-10-05"
 
 
 # We'll access these services through their external names.
-workers_dev = false 
+workers_dev = false
+logpush = true
 
 [[rules]]
 globs = ["**/*.wasm"]
@@ -62,4 +63,3 @@ route = { pattern = "images.rollup.id", custom_domain = true, zone_name = "rollu
 # - maximum: 6 hours (21600)
 UPLOAD_WINDOW_SECONDS = 200
 HASH_INTERNAL_CLOUDFLARE_ACCOUNT_ID = "VqQy1abBMHYDZwVsTbsSMw"
-

--- a/platform/logbridge/.eslintrc.json
+++ b/platform/logbridge/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "env": {
+    "browser": true,
+    "es2022": true,
+    "node": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"]
+}

--- a/platform/logbridge/package.json
+++ b/platform/logbridge/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@proofzero/logbridge",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "wrangler publish --dry-run --outdir=dist",
+    "check": "run-s format:check lint:check types:check",
+    "format": "run-s format:src",
+    "format:src": "prettier --write src",
+    "format:check": "run-s format:check:src",
+    "format:check:src": "prettier --check src",
+    "lint": "eslint --fix src test",
+    "lint:check": "run-s lint:check:src",
+    "lint:check:src": "eslint src",
+    "types:check": "tsc --project tsconfig.json",
+    "dev": "echo 'Service does not function locally. Deploy instead'",
+    "deploy": "wrangler publish",
+    "test": "run-s check"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "4.20221111.1",
+    "@types/node": "18.15.3",
+    "@typescript-eslint/eslint-plugin": "5.42.1",
+    "@typescript-eslint/parser": "5.42.1",
+    "env-cmd": "10.1.0",
+    "eslint": "8.28.0",
+    "eslint-config-prettier": "8.5.0",
+    "npm-run-all": "4.1.5",
+    "prettier": "2.7.1",
+    "typescript": "5.0.4",
+    "wrangler": "2.14.0"
+  }
+}

--- a/platform/logbridge/src/index.ts
+++ b/platform/logbridge/src/index.ts
@@ -1,0 +1,55 @@
+import type { Request } from '@cloudflare/workers-types'
+import type { Environment, LokiRequestPayload } from './types'
+import {
+  getLogpushEntriesFromRequest,
+  convertLogpushEntriesToLokiStreams,
+} from './transformations'
+
+export default {
+  async fetch(request: Request, env: Environment) {
+    // Check pre-shared key header
+    const PRESHARED_AUTH_HEADER_KEY = 'X-LOGBRIDGE-PSK'
+    const psk = request.headers.get(PRESHARED_AUTH_HEADER_KEY)
+    if (psk !== env.SECRET_LOGPUSH_JOB_AUTHZ_KEY) {
+      return new Response('Unauthorized to use Logbridge.', {
+        status: 403,
+      })
+    }
+
+    const contentEncoding = request.headers.get('content-encoding')
+    if (contentEncoding !== 'gzip') {
+      return new Response(undefined, { status: 204 })
+    }
+    //Convert gzip batched logpush data to array of logpush entries
+    const logpushEntries = await getLogpushEntriesFromRequest(request)
+
+    //If no logs, or CF Logpush initial "handshake", then early return
+    if (logpushEntries && logpushEntries.length === 0)
+      return new Response(undefined, { status: 204 })
+
+    //Convert Logpush entries to Loki ones
+    const lokiPayload: LokiRequestPayload =
+      convertLogpushEntriesToLokiStreams(logpushEntries)
+
+    const result = await sendLokiStreamsToLoki(lokiPayload, env)
+    return result
+  },
+}
+
+async function sendLokiStreamsToLoki(
+  lokiPayload: LokiRequestPayload,
+  env: Environment
+) {
+  // Post data to Grafana Loki
+  const result = await fetch(`${env.INTERNAL_LOKI_URL}/loki/api/v1/push`, {
+    method: 'POST',
+    body: JSON.stringify(lokiPayload),
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization:
+        'Basic ' + btoa(`${env.INTERNAL_LOKI_USER}:${env.SECRET_LOKI_API_KEY}`),
+    },
+  })
+  console.log(await result.text())
+  return result
+}

--- a/platform/logbridge/src/transformations.ts
+++ b/platform/logbridge/src/transformations.ts
@@ -1,0 +1,157 @@
+import {
+  WorkerTraceEvent,
+  LokiStreamLabels,
+  LokiStreamValue,
+  LokiRequestPayload,
+  WorkerLogEntry,
+  WorkerExceptionEntry,
+} from './types'
+
+export async function getLogpushEntriesFromRequest(
+  request: Request
+): Promise<WorkerTraceEvent[]> {
+  //Assumed gzip compressed data
+  const buf = await request.arrayBuffer()
+  const enc = new TextDecoder('utf-8')
+  const blob = new Blob([buf])
+  const ds = new DecompressionStream('gzip')
+  const decompressedStream = blob.stream().pipeThrough(ds)
+  const buffer = await new Response(decompressedStream).arrayBuffer()
+  const decompressed = new Uint8Array(buffer)
+  const ndjson = enc.decode(decompressed)
+
+  //Entries are newline-delimiter separated; we convert them to JSON
+  const logpushEntryStrings = ndjson.split('\n')
+  let jsonLogpushEntries = logpushEntryStrings
+    .filter((e) => e !== '')
+    .map((e) => JSON.parse(e))
+
+  if (
+    jsonLogpushEntries &&
+    jsonLogpushEntries.length === 1 &&
+    //CF Logpush initial "handshake" log entry
+    jsonLogpushEntries[0]['content'] &&
+    jsonLogpushEntries[0]['content'] === 'test'
+  )
+    return []
+  else {
+    //Filter out entries without log/exception messages, like static asset fetches
+    jsonLogpushEntries = (jsonLogpushEntries as WorkerTraceEvent[]).filter(
+      (e) => e.Logs.length || e.Exceptions.length
+    )
+  }
+  return jsonLogpushEntries
+}
+
+function getEnvironmentFromWorkerName(workerName: string): string | null {
+  const result = null
+  const nameSegments = workerName.split('-')
+  if (nameSegments.length === 2) {
+    const envName = nameSegments[1]
+    if (['dev', 'next', 'current'].includes(envName)) return envName
+  }
+  return result
+}
+
+function extractTraceFromMessageArray(
+  messages: string[]
+): Record<string, string> | undefined {
+  for (const [index, message] of messages.entries()) {
+    if (message.startsWith('{')) {
+      try {
+        const unescapedTraceString = message.replaceAll('\\"', '"')
+        const traceInfo = JSON.parse(unescapedTraceString)
+        if (traceInfo['traceparent'] || traceInfo['tracespan']) {
+          //If it's a trace segment of a log line, remove it from the
+          //message segments array and return it as JSON
+          messages.splice(index, 1)
+          return traceInfo
+        }
+      } catch {
+        return undefined
+      }
+    }
+  }
+  return undefined
+}
+
+export function createLokiStreamLabels(
+  wte: WorkerTraceEvent
+): LokiStreamLabels {
+  let result: LokiStreamLabels = { worker: wte.ScriptName }
+  const envName = getEnvironmentFromWorkerName(wte.ScriptName)
+  if (envName) result = { ...result, env: envName }
+  return result
+}
+
+export function createLokiStreamValues(
+  wte: WorkerTraceEvent
+): LokiStreamValue[] {
+  const result: LokiStreamValue[] = []
+
+  //Merge and sort regular logs and exception logs by timestamp
+  let allLogs: (WorkerLogEntry | WorkerExceptionEntry)[] = wte.Logs
+  allLogs = allLogs.concat(wte.Exceptions)
+
+  const allTimeSortedLogs = allLogs.sort(
+    (a, b) => a.TimestampMs - b.TimestampMs
+  )
+
+  for (const [index, logEntry] of allTimeSortedLogs.entries()) {
+    //Arguments passed to console.log() or console.debug() are captured in
+    //reverse order in CF logging, hence the need to reverse here
+    let lokiMessage: Record<
+      string,
+      string | Record<string, string> | undefined
+    > = {}
+    if (logEntry.Message instanceof Array) {
+      const workerLogEntry = logEntry as WorkerLogEntry
+      const traceRecord = extractTraceFromMessageArray(workerLogEntry.Message)
+      const messageFromLogArgs = workerLogEntry.Message.reverse().join(' ')
+      lokiMessage = {
+        worker: wte.ScriptName,
+        message: messageFromLogArgs,
+        level: workerLogEntry.Level,
+        requestUrl: wte.Event.Request.URL,
+        trace: traceRecord,
+      }
+    } else {
+      const exceptionLogEntry = logEntry as WorkerExceptionEntry
+      lokiMessage = {
+        worker: wte.ScriptName,
+        message: exceptionLogEntry.Message,
+        level: 'exception',
+        exceptionName: exceptionLogEntry.Name,
+        requestUrl: wte.Event.Request.URL,
+        trace: '',
+      }
+    }
+
+    //Add a return status code to the last message created for a request
+    //This will typically be the message closest to the response being sent
+    if (index === allTimeSortedLogs.length - 1) {
+      lokiMessage = { ...lokiMessage, statusCode: wte.Event.Response.Status }
+    }
+    const streamValue: LokiStreamValue = [
+      (logEntry.TimestampMs * 1000000).toString(),
+      JSON.stringify(lokiMessage),
+    ]
+    result.push(streamValue)
+  }
+  return result
+}
+
+export function convertLogpushEntriesToLokiStreams(
+  logpushEntries: WorkerTraceEvent[]
+) {
+  const lokiPayload: LokiRequestPayload = { streams: [] }
+  logpushEntries.forEach((logpushEntry) => {
+    const currentStream = {
+      stream: createLokiStreamLabels(logpushEntry),
+      values: createLokiStreamValues(logpushEntry),
+    }
+
+    lokiPayload.streams.push(currentStream)
+  })
+  return lokiPayload
+}

--- a/platform/logbridge/src/types.ts
+++ b/platform/logbridge/src/types.ts
@@ -1,0 +1,55 @@
+export type Environment = {
+  INTERNAL_LOKI_USER: string
+  SECRET_LOKI_API_KEY: string
+  INTERNAL_LOKI_URL: string
+  SECRET_LOGPUSH_JOB_AUTHZ_KEY: string
+}
+
+export type WorkerLogEntry = {
+  Level: 'debug' | 'error' | 'log' | 'warn' | 'info'
+  Message: string[] //Contains args given to console.log/debug in reverse order
+  TimestampMs: number
+}
+
+export type WorkerExceptionEntry = {
+  Name: string
+  Message: string
+  TimestampMs: number
+}
+
+export type WorkerEventEntry = {
+  Request: {
+    URL: string
+    Method: 'GET' | 'POST' //..others?
+  }
+  Response: {
+    Status: string //HTTP status code
+  }
+}
+
+export type WorkerTraceEvent = {
+  Event: WorkerEventEntry
+  EventTimestampMs: number
+  EventType: 'fetch'
+  Exceptions: WorkerExceptionEntry[]
+  Logs: WorkerLogEntry[]
+  Outcome: 'ok' | 'cancelled' | 'exception'
+  ScriptName: string
+}
+
+export type LokiStreamLabels = {
+  worker: string
+  env?: string
+  statusCode?: string
+}
+
+export type LokiStreamValue = [unixtime: string, stringifiedJsonMessage: string]
+
+export type LokiStream = {
+  stream: LokiStreamLabels
+  values: LokiStreamValue[]
+}
+
+export type LokiRequestPayload = {
+  streams: LokiStream[]
+}

--- a/platform/logbridge/tsconfig.json
+++ b/platform/logbridge/tsconfig.json
@@ -1,0 +1,105 @@
+{
+	"compilerOptions": {
+		/* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+		/* Projects */
+		// "incremental": true,                              /* Enable incremental compilation */
+		// "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+		// "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
+		// "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
+		// "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+		// "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+		/* Language and Environment */
+		"target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+		"lib": [
+			"es2021"
+		] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
+		"jsx": "react" /* Specify what JSX code is generated. */,
+		// "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+		// "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+		// "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
+		// "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+		// "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
+		// "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
+		// "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+		// "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+
+		/* Modules */
+		"module": "es2022" /* Specify what module code is generated. */,
+		// "rootDir": "./",                                  /* Specify the root folder within your source files. */
+		"moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
+		// "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+		// "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+		// "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+		// "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
+		"types": [
+			"@cloudflare/workers-types"
+		] /* Specify type package names to be included without being referenced in a source file. */,
+		// "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+		"resolveJsonModule": true /* Enable importing .json files */,
+		// "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
+
+		/* JavaScript Support */
+		"allowJs": true /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */,
+		"checkJs": false /* Enable error reporting in type-checked JavaScript files. */,
+		// "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
+
+		/* Emit */
+		// "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+		// "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+		// "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+		// "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+		// "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
+		// "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+		// "removeComments": true,                           /* Disable emitting comments. */
+		"noEmit": true /* Disable emitting files from a compilation. */,
+		// "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+		// "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
+		// "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+		// "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+		// "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+		// "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+		// "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+		// "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+		// "newLine": "crlf",                                /* Set the newline character for emitting files. */
+		// "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+		// "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
+		// "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+		// "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
+		// "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+		// "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+		/* Interop Constraints */
+		"isolatedModules": true /* Ensure that each file can be safely transpiled without relying on other imports. */,
+		"allowSyntheticDefaultImports": true /* Allow 'import x from y' when a module doesn't have a default export. */,
+		// "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,
+		// "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+		"forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+
+		/* Type Checking */
+		"strict": true /* Enable all strict type-checking options. */,
+		// "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+		// "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
+		// "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+		// "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
+		// "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+		// "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
+		// "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
+		// "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+		// "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
+		// "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
+		// "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+		// "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+		// "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+		// "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
+		// "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+		// "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
+		// "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+		// "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+		/* Completeness */
+		// "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+		"skipLibCheck": true /* Skip type checking all .d.ts files. */
+	}
+}

--- a/platform/logbridge/wrangler.toml
+++ b/platform/logbridge/wrangler.toml
@@ -1,0 +1,6 @@
+name = "logbridge"
+compatibility_date = "2023-02-24"
+main = "./src/index.ts"
+workers_dev = false
+
+routes = [{ pattern = "logbridge.rollup.id", custom_domain = true }]

--- a/platform/object/wrangler.toml
+++ b/platform/object/wrangler.toml
@@ -2,73 +2,58 @@ name = "object"
 main = "src/index.ts"
 compatibility_date = "2022-10-26"
 node_compat = true
+logpush = true
 
-durable_objects.bindings = [
-  { name = "Meta", class_name = "Meta" }
-]
+durable_objects.bindings = [{ name = "Meta", class_name = "Meta" }]
 r2_buckets = [
   { binding = "Bucket", bucket_name = "rollup-dev", preview_bucket_name = "rollup-dev" },
 ]
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalytics"  },
+  { binding = "Analytics", dataset = "PlatformAnalytics" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [dev]
 port = 9595
 local_protocol = "http"
 
 [env.dev]
-durable_objects.bindings = [
-  { name = "Meta", class_name = "Meta" }
-]
+durable_objects.bindings = [{ name = "Meta", class_name = "Meta" }]
 r2_buckets = [
   { binding = "Bucket", bucket_name = "rollup-dev", preview_bucket_name = "rollup-dev" },
 ]
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalyticsDev"  },
+  { binding = "Analytics", dataset = "PlatformAnalyticsDev" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [env.next]
-durable_objects.bindings = [
-  { name = "Meta", class_name = "Meta" }
-]
+durable_objects.bindings = [{ name = "Meta", class_name = "Meta" }]
 r2_buckets = [
   { binding = "Bucket", bucket_name = "rollup-next", preview_bucket_name = "rollup-next" },
 ]
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalyticsNext"  },
+  { binding = "Analytics", dataset = "PlatformAnalyticsNext" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [env.current]
-durable_objects.bindings = [
-  { name = "Meta", class_name = "Meta" }
-]
+durable_objects.bindings = [{ name = "Meta", class_name = "Meta" }]
 r2_buckets = [
   { binding = "Bucket", bucket_name = "rollup-current", preview_bucket_name = "rollup-current" },
 ]
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalyticsCurrent"  },
+  { binding = "Analytics", dataset = "PlatformAnalyticsCurrent" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [[migrations]]
 tag = "v0"

--- a/platform/starbase/wrangler.toml
+++ b/platform/starbase/wrangler.toml
@@ -2,6 +2,7 @@ name = "starbase"
 main = "src/index.ts"
 compatibility_date = "2022-10-26"
 node_compat = true
+logpush = true
 
 
 # #############################################################################
@@ -17,9 +18,7 @@ workers_dev = false
 # -----------------------------------------------------------------------------
 # A list of other Clouflare services bound to this service.
 
-services = [
-  { binding = "Edges", service = "edges" }
-]
+services = [{ binding = "Edges", service = "edges" }]
 
 # Durable Objects
 # -----------------------------------------------------------------------------
@@ -33,19 +32,17 @@ durable_objects.bindings = [
 
 kv_namespaces = [
   { binding = "FIXTURES", id = "29bcce9f29d9499688da216bcc3dbb49", preview_id = "afbd7707df58426c9926a483c979b9a5" },
-  { binding = "LOOKUP", id = "27035c39f40343a4a0deab740f2b9fcc", preview_id = "883765b4372d42bea90c67e2e6bfb64b" }
+  { binding = "LOOKUP", id = "27035c39f40343a4a0deab740f2b9fcc", preview_id = "883765b4372d42bea90c67e2e6bfb64b" },
 ]
 
 # Analytics
 # -----------------------------------------------------------------------------
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalytics"  },
+  { binding = "Analytics", dataset = "PlatformAnalytics" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 # Secrets
 # -----------------------------------------------------------------------------
@@ -68,12 +65,10 @@ inspector_port = 11301
 local_protocol = "http"
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalytics"  },
+  { binding = "Analytics", dataset = "PlatformAnalytics" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [[migrations]]
 tag = "v2"
@@ -83,31 +78,24 @@ tag = "v2"
 # renamed_classes = [
 #   { from = "OldName", to = "NewName" }
 # ]
-deleted_classes = [
-  "StarbaseContract",
-  "StarbaseUser",
-]
+deleted_classes = ["StarbaseContract", "StarbaseUser"]
 
 # Environment: dev
 # -----------------------------------------------------------------------------
 
 [env.dev]
 
-services = [
-  { binding = "Edges", service = "edges-dev" }
-]
+services = [{ binding = "Edges", service = "edges-dev" }]
 
 durable_objects.bindings = [
   { name = "StarbaseApp", class_name = "StarbaseApplication" },
 ]
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalyticsDev"  },
+  { binding = "Analytics", dataset = "PlatformAnalyticsDev" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [env.dev.vars]
 ENVIRONMENT = "dev"
@@ -117,21 +105,17 @@ ENVIRONMENT = "dev"
 
 [env.next]
 
-services = [
-  { binding = "Edges", service = "edges-next" }
-]
+services = [{ binding = "Edges", service = "edges-next" }]
 
 durable_objects.bindings = [
   { name = "StarbaseApp", class_name = "StarbaseApplication" },
 ]
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalyticsNext"  },
+  { binding = "Analytics", dataset = "PlatformAnalyticsNext" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [env.next.vars]
 ENVIRONMENT = "next"
@@ -141,21 +125,17 @@ ENVIRONMENT = "next"
 
 [env.current]
 
-services = [
-  { binding = "Edges", service = "edges-current" }
-]
+services = [{ binding = "Edges", service = "edges-current" }]
 
 durable_objects.bindings = [
   { name = "StarbaseApp", class_name = "StarbaseApplication" },
 ]
 
 analytics_engine_datasets = [
-  { binding = "Analytics", dataset = "PlatformAnalyticsCurrent"  },
+  { binding = "Analytics", dataset = "PlatformAnalyticsCurrent" },
 ]
 
-unsafe.bindings = [
-  { type = "metadata", name = "ServiceDeploymentMetadata" },
-]
+unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [env.current.vars]
 ENVIRONMENT = "current"

--- a/scripts/create-cf-logpush-job.js
+++ b/scripts/create-cf-logpush-job.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+//Usage: CLOUDFLARE_ACCOUNT='xxx' CLOUDFLARE_API_KEY='xxx' LOGBRIDGE_URL='xxx' AUTHORIZATION_HEADER_PSK='xxx' ./create-cf-logpush-jobs.js
+//Environment variables that need to be set prior to running script
+const CLOUDFLARE_ACCOUNT = process.env.CLOUDFLARE_ACCOUNT
+const CLOUDFLARE_API_KEY = process.env.CLOUDFLARE_API_KEY
+const LOGBRIDGE_URL = process.env.LOGBRIDGE_URL
+const AUTHORIZATION_HEADER_PSK = process.env.AUTHORIZATION_HEADER_PSK
+
+//Pre-check
+if (
+  CLOUDFLARE_ACCOUNT &&
+  CLOUDFLARE_API_KEY &&
+  LOGBRIDGE_URL &&
+  AUTHORIZATION_HEADER_PSK
+) {
+  //Create URL and header
+  const AUTHORIZATION_HEADER_KEY = 'X-LOGBRIDGE-PSK'
+  const logpushDestinationURL = new URL(LOGBRIDGE_URL)
+  logpushDestinationURL.searchParams.append(
+    `header_${AUTHORIZATION_HEADER_KEY}`,
+    AUTHORIZATION_HEADER_PSK
+  )
+
+  const WORKER_LOG_FIELDS =
+    'Event,EventTimestampMs,Exceptions,Logs,Outcome,ScriptName'
+
+  const requestPayload = {
+    name: 'logbridge',
+    logpull_options: `fields=${WORKER_LOG_FIELDS}&timestamps=unix`,
+    destination_conf: logpushDestinationURL.toString(),
+    max_upload_bytes: 5000000,
+    max_upload_records: 1000,
+    dataset: 'workers_trace_events',
+    frequency: 'high',
+    enabled: true,
+  }
+
+  const fetchOpts = {
+    headers: {
+      Authorization: `Bearer ${CLOUDFLARE_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+    body: JSON.stringify(requestPayload),
+  }
+
+  const fetchUrl = `https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT}/logpush/jobs`
+
+  fetch(fetchUrl, fetchOpts)
+    .then((res) => {
+      console.log('Result:', { code: res.status, status: res.statusText })
+      return res.text()
+    })
+    .then((text) => {
+      console.log(text)
+    })
+} else {
+  console.error('Required environment variables not set correctly.')
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6003,6 +6003,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@proofzero/logbridge@workspace:platform/logbridge":
+  version: 0.0.0-use.local
+  resolution: "@proofzero/logbridge@workspace:platform/logbridge"
+  dependencies:
+    "@cloudflare/workers-types": 4.20221111.1
+    "@types/node": 18.15.3
+    "@typescript-eslint/eslint-plugin": 5.42.1
+    "@typescript-eslint/parser": 5.42.1
+    env-cmd: 10.1.0
+    eslint: 8.28.0
+    eslint-config-prettier: 8.5.0
+    npm-run-all: 4.1.5
+    prettier: 2.7.1
+    typescript: 5.0.4
+    wrangler: 2.14.0
+  languageName: unknown
+  linkType: soft
+
 "@proofzero/packages@workspace:packages":
   version: 0.0.0-use.local
   resolution: "@proofzero/packages@workspace:packages"


### PR DESCRIPTION
### Description

Implementation of centralized log management through Logbridge, the new Cloudflare Logpush data transformer and dispatcher service. Pushes correctly-shaped data to Grafana Loki.

CF Logpush job has been set up with a pre-shared key, which is passed as an authorization header to all the payloads CFF Logpush sends to Logbridge.

Note: Logbridge is a CF-only service and doesn't function locally. It is also a single-instance service for all of our environments.

### Related Issues

- Closes #1790

### Testing

- Deployed in Dev and tested 

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
