### PR TITLE
fix(address): handle personal and work profile types

### DIFF
--- a/platform/address/src/nodes/microsoft.ts
+++ b/platform/address/src/nodes/microsoft.ts
@@ -52,7 +52,15 @@ export default class MicrosoftAddress extends OAuthAddress {
       return btoa(data)
     } else {
       console.error(await response.text())
-      throw new Error("couldn't fetch photo")
+
+      const gradientUrl = await this.node.class.getGradient()
+      if (!gradientUrl) return ''
+      const gradient = await fetch(gradientUrl)
+      let data = ''
+      new Uint8Array(await gradient.arrayBuffer()).forEach(
+        (byte) => (data += String.fromCharCode(byte))
+      )
+      return btoa(data)
     }
   }
 

--- a/platform/address/src/types.ts
+++ b/platform/address/src/types.ts
@@ -93,10 +93,25 @@ export interface GoogleOAuthProfile {
   picture: string
 }
 
-export interface MicrosoftOAuthProfile {
+export interface MicrosoftOAuthProfileCommon {
   email: string
-  name: string
 }
+
+export interface MicrosoftOAuthProfilePersonal
+  extends MicrosoftOAuthProfileCommon {
+  givenname: string
+  familyname: string
+}
+
+export interface MicrosoftOAuthProfileWork extends MicrosoftOAuthProfileCommon {
+  name: string
+  given_name: string
+  family_name: string
+}
+
+export type MicrosoftOAuthProfile =
+  | MicrosoftOAuthProfilePersonal
+  | MicrosoftOAuthProfileWork
 
 export interface TwitterOAuthProfile {
   name: string


### PR DESCRIPTION
---

### Description

Introduces personal and work profile types.

Fetches gradient as the avatar if the upstream avatar endpoint fails.

### Related Issues

- Closes #2197

### Testing

- [x] Manual

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [x] I have updated the documentation (if necessary)