### PR TITLE
fix(passport): Fix disappearing `prompt=consent` param

### DIFF
--- a/apps/console/app/routes/apps/$clientId/team.tsx
+++ b/apps/console/app/routes/apps/$clientId/team.tsx
@@ -47,7 +47,7 @@ export const loader: LoaderFunction = async ({ request, context, params }) => {
   // set their e-mail to the one just connected
   // All other cases are ambiguous and we should not make assumptions
   const requestURL = new URL(request.url)
-  const connectResult = requestURL.searchParams.get('connect_result')
+  const connectResult = requestURL.searchParams.get('rollup_result')
   if (connectResult && connectResult === 'SUCCESS') {
     if (connectedEmails.length === 1) {
       const starbaseClient = createStarbaseClient(Starbase, {
@@ -101,9 +101,9 @@ export const action: ActionFunction = async ({ request, context, params }) => {
   // history erasure so searchParams
   // are regenerated; manual removal
   const requestURL = new URL(request.url)
-  const connectResult = requestURL.searchParams.get('connect_result')
+  const connectResult = requestURL.searchParams.get('rollup_result')
   if (connectResult) {
-    requestURL.searchParams.delete('connect_result')
+    requestURL.searchParams.delete('rollup_result')
     return redirect(requestURL.toString())
   }
 
@@ -134,7 +134,7 @@ export default () => {
     qp.append('client_id', 'console')
 
     qp.append('redirect_uri', currentURL.toString())
-    qp.append('prompt', 'connect')
+    qp.append('rollup_action', 'connect')
     qp.append('login_hint', 'email microsoft google apple')
 
     window.location.href = `${PASSPORT_URL}/authorize?${qp.toString()}`

--- a/apps/passport/app/components/addresses/AddressListItem.tsx
+++ b/apps/passport/app/components/addresses/AddressListItem.tsx
@@ -105,7 +105,7 @@ export const AddressListItem = ({
     url.search = ''
 
     const qp = new URLSearchParams()
-    qp.append('prompt', 'reconnect')
+    qp.append('rollup_action', 'reconnect')
     qp.append('client_id', 'passport')
     qp.append('state', 'skip')
     qp.append('login_hint', type)

--- a/apps/passport/app/routes/authenticate/$clientId.tsx
+++ b/apps/passport/app/routes/authenticate/$clientId.tsx
@@ -1,7 +1,7 @@
 import { Outlet, useLoaderData } from '@remix-run/react'
 import { json } from '@remix-run/cloudflare'
 import { getStarbaseClient } from '~/platform.server'
-import { getConsoleParams } from '~/session.server'
+import { getAuthzCookieParams } from '~/session.server'
 
 import sideGraphics from '~/assets/auth-side-graphics.svg'
 import LogoIndigo from '~/assets/PassportLogoIndigo.svg'
@@ -29,17 +29,20 @@ export const loader: LoaderFunction = async ({ request, context, params }) => {
     }
   }
 
-  const cp = await getConsoleParams(request, context.env)
+  const cp = await getAuthzCookieParams(request, context.env)
 
-  let prompt
-  if (['connect', 'reconnect'].includes(cp?.prompt)) {
-    prompt = cp?.prompt
+  let rollup_action
+  if (
+    cp.rollup_action &&
+    ['connect', 'reconnect'].includes(cp?.rollup_action)
+  ) {
+    rollup_action = cp?.rollup_action
   }
 
   return json({
     clientId: params.clientId,
     appProps,
-    prompt,
+    rollup_action,
   })
 }
 
@@ -61,7 +64,7 @@ export const meta: MetaFunction = ({
 })
 
 export default () => {
-  const { clientId, appProps, prompt } = useLoaderData()
+  const { clientId, appProps, rollup_action } = useLoaderData()
 
   return (
     <div className={'flex flex-row h-screen justify-center items-center'}>
@@ -73,7 +76,7 @@ export default () => {
         <img src={sideGraphics} alt="Background graphics" />
       </div>
       <div className={'basis-full basis-full lg:basis-3/5'}>
-        <Outlet context={{ clientId, appProps, prompt }} />
+        <Outlet context={{ clientId, appProps, rollup_action }} />
       </div>
     </div>
   )

--- a/apps/passport/app/routes/authenticate/$clientId/account.tsx
+++ b/apps/passport/app/routes/authenticate/$clientId/account.tsx
@@ -14,7 +14,11 @@ import {
 import { Authentication } from '~/components'
 import { AuthButton } from '@proofzero/design-system/src/molecules/auth-button/AuthButton'
 import { getAccountClient } from '~/platform.server'
-import { getConsoleParams, getUserSession, parseJwt } from '~/session.server'
+import {
+  getAuthzCookieParams,
+  getUserSession,
+  parseJwt,
+} from '~/session.server'
 import { Text } from '@proofzero/design-system/src/atoms/text/Text'
 
 export const loader: LoaderFunction = async ({ request, context, params }) => {
@@ -40,13 +44,13 @@ export const loader: LoaderFunction = async ({ request, context, params }) => {
 }
 
 export const action: ActionFunction = async ({ request, context, params }) => {
-  const consoleParams = await getConsoleParams(
+  const authzCookieParams = await getAuthzCookieParams(
     request,
     context.env,
     params.clientId
   )
 
-  const { redirectUri, state, scope, clientId, prompt } = consoleParams
+  const { redirectUri, state, scope, clientId, prompt } = authzCookieParams
 
   const qp = new URLSearchParams()
   qp.append('client_id', clientId)

--- a/apps/passport/app/routes/authenticate/$clientId/email/verify.tsx
+++ b/apps/passport/app/routes/authenticate/$clientId/email/verify.tsx
@@ -12,7 +12,7 @@ import {
   useTransition,
 } from '@remix-run/react'
 import {
-  getConsoleParams,
+  getAuthzCookieParams,
   getJWTConditionallyFromSession,
 } from '~/session.server'
 import { getAddressClient } from '~/platform.server'
@@ -41,7 +41,7 @@ export const action: ActionFunction = async ({ request, context, params }) => {
   const { addressURN, successfulVerification } = await actionRes.json()
 
   if (successfulVerification) {
-    const appData = await getConsoleParams(request, context.env)
+    const appData = await getAuthzCookieParams(request, context.env)
     const addressClient = getAddressClient(
       addressURN,
       context.env,
@@ -54,7 +54,7 @@ export const action: ActionFunction = async ({ request, context, params }) => {
         context.env,
         appData?.clientId
       ),
-      force: !appData || appData.prompt !== 'connect',
+      force: !appData || appData.rollup_action !== 'connect',
     })
 
     return authenticateAddress(

--- a/apps/passport/app/routes/authenticate/cancel.tsx
+++ b/apps/passport/app/routes/authenticate/cancel.tsx
@@ -1,29 +1,37 @@
+import { InternalServerError } from '@proofzero/errors'
 import { LoaderFunction, redirect } from '@remix-run/cloudflare'
 import {
   destroyAuthenticationParamsSession,
-  destroyConsoleParamsSession,
-  getConsoleParams,
+  destroyAuthzCookieParamsSession,
+  getAuthzCookieParams,
 } from '~/session.server'
 
 export const loader: LoaderFunction = async ({ request, context }) => {
-  const cp = await getConsoleParams(request, context.env)
-  if (!cp) {
-    throw new Error('No console params')
+  const authzCookieParams = await getAuthzCookieParams(request, context.env)
+  if (!authzCookieParams) {
+    throw new InternalServerError({ message: 'No authorization params cookie' })
   }
 
-  if (!['connect', 'reconnect'].includes(cp.prompt)) {
-    throw new Error('Not a connect flow')
+  if (
+    !authzCookieParams.rollup_action ||
+    !['connect', 'reconnect'].includes(authzCookieParams.rollup_action)
+  ) {
+    throw new InternalServerError({ message: 'Not a connect flow' })
   }
 
   const headers = new Headers()
   headers.append(
     'Set-Cookie',
-    await destroyConsoleParamsSession(request, context.env, cp.clientId)
+    await destroyAuthzCookieParamsSession(
+      request,
+      context.env,
+      authzCookieParams.clientId
+    )
   )
 
   headers.append(
     'Set-Cookie',
-    await destroyConsoleParamsSession(request, context.env)
+    await destroyAuthzCookieParamsSession(request, context.env)
   )
 
   headers.append(
@@ -32,11 +40,13 @@ export const loader: LoaderFunction = async ({ request, context }) => {
   )
 
   const qp = new URLSearchParams()
-  qp.append('state', cp.state)
-  qp.append('client_id', cp.clientId)
-  qp.append('redirect_uri', cp.redirectUri)
-  qp.append('scope', cp.scope.join(' '))
-  qp.append('connect_result', 'CANCEL')
+  qp.append('state', authzCookieParams.state)
+  qp.append('client_id', authzCookieParams.clientId)
+  qp.append('redirect_uri', authzCookieParams.redirectUri)
+  qp.append('scope', authzCookieParams.scope.join(' '))
+  qp.append('rollup_result', 'CANCEL')
+
+  if (authzCookieParams.prompt) qp.append('prompt', authzCookieParams.prompt)
 
   return redirect(`/authorize?${qp.toString()}`, { headers })
 }

--- a/apps/passport/app/routes/authorize.tsx
+++ b/apps/passport/app/routes/authorize.tsx
@@ -88,10 +88,6 @@ export type LoaderData = {
 }
 
 export const loader: LoaderFunction = async ({ request, context }) => {
-  console.debug(
-    'PASSPORT ****************************',
-    new URL(request.url).searchParams
-  )
   const { clientId, redirectUri, state, prompt, rollup_action } =
     context.authzQueryParams
 

--- a/apps/passport/app/routes/connect/$address/sign.tsx
+++ b/apps/passport/app/routes/connect/$address/sign.tsx
@@ -6,7 +6,7 @@ import { AddressURNSpace } from '@proofzero/urns/address'
 import { generateHashedIDRef } from '@proofzero/urns/idref'
 import { CryptoAddressType, NodeType } from '@proofzero/types/address'
 import {
-  getConsoleParams,
+  getAuthzCookieParams,
   getJWTConditionallyFromSession,
 } from '../../../session.server'
 
@@ -51,7 +51,7 @@ export const loader: LoaderFunction = async ({ request, context, params }) => {
 }
 
 export const action: ActionFunction = async ({ request, context, params }) => {
-  const appData = await getConsoleParams(request, context.env)
+  const appData = await getAuthzCookieParams(request, context.env)
 
   const { address } = params
   if (!address) throw new Error('No address included in request')
@@ -77,11 +77,11 @@ export const action: ActionFunction = async ({ request, context, params }) => {
       context.env,
       appData?.clientId
     ),
-    forceAccountCreation: !appData || appData.prompt !== 'connect',
+    forceAccountCreation: !appData || appData.rollup_action !== 'connect',
   })
 
-  if (appData?.prompt === 'connect' && existing) {
-    return redirect(`${appData.redirectUri}?connect_result=ALREADY_CONNECTED`)
+  if (appData?.rollup_action === 'connect' && existing) {
+    return redirect(`${appData.redirectUri}?rollup_result=ALREADY_CONNECTED`)
   }
 
   // TODO: handle the error case

--- a/apps/passport/app/routes/connect/$address/token.tsx
+++ b/apps/passport/app/routes/connect/$address/token.tsx
@@ -4,7 +4,7 @@ import { AddressURNSpace } from '@proofzero/urns/address'
 import { generateHashedIDRef } from '@proofzero/urns/idref'
 import type { LoaderFunction } from '@remix-run/cloudflare'
 import { json } from '@remix-run/cloudflare'
-import { getConsoleParams } from '~/session.server'
+import { getAuthzCookieParams } from '~/session.server'
 
 import { getAddressClient } from '../../../platform.server'
 import { authenticateAddress } from '../../../utils/authenticate.server'
@@ -32,7 +32,7 @@ export const loader: LoaderFunction = async ({ request, context, params }) => {
   )
   const accountURN = await addressClient.getAccount.query()
 
-  const appData = await getConsoleParams(request, context.env)
+  const appData = await getAuthzCookieParams(request, context.env)
 
   return authenticateAddress(
     addressURN,

--- a/apps/passport/app/routes/connect/discord/callback.ts
+++ b/apps/passport/app/routes/connect/discord/callback.ts
@@ -10,7 +10,7 @@ import type { OAuthData } from '@proofzero/platform.address/src/types'
 import { initAuthenticator, getDiscordStrategy } from '~/auth.server'
 import { getAddressClient } from '~/platform.server'
 import {
-  getConsoleParams,
+  getAuthzCookieParams,
   getJWTConditionallyFromSession,
 } from '~/session.server'
 import {
@@ -21,7 +21,7 @@ import {
 export const loader: LoaderFunction = async ({ request, context }) => {
   await checkOAuthError(request, context.env)
 
-  const appData = await getConsoleParams(request, context.env)
+  const appData = await getAuthzCookieParams(request, context.env)
 
   const authenticator = initAuthenticator(context.env)
   authenticator.use(getDiscordStrategy(context.env))
@@ -54,7 +54,7 @@ export const loader: LoaderFunction = async ({ request, context }) => {
       context.env,
       appData?.clientId
     ),
-    force: !appData || appData.prompt !== 'connect',
+    force: !appData || appData.rollup_action !== 'connect',
   })
 
   await addressClient.setOAuthData.mutate(authRes)

--- a/apps/passport/app/routes/connect/github/callback.ts
+++ b/apps/passport/app/routes/connect/github/callback.ts
@@ -14,7 +14,7 @@ import { GitHubStrategyDefaultName } from 'remix-auth-github'
 import { NodeType, OAuthAddressType } from '@proofzero/types/address'
 import type { OAuthData } from '@proofzero/platform.address/src/types'
 import {
-  getConsoleParams,
+  getAuthzCookieParams,
   getJWTConditionallyFromSession,
 } from '~/session.server'
 
@@ -24,7 +24,7 @@ export const loader: LoaderFunction = async ({
 }: LoaderArgs) => {
   await checkOAuthError(request, context.env)
 
-  const appData = await getConsoleParams(request, context.env)
+  const appData = await getAuthzCookieParams(request, context.env)
 
   const authenticator = initAuthenticator(context.env)
   authenticator.use(getGithubAuthenticator(context.env))
@@ -58,7 +58,7 @@ export const loader: LoaderFunction = async ({
       context.env,
       appData?.clientId
     ),
-    force: !appData || appData.prompt !== 'connect',
+    force: !appData || appData.rollup_action !== 'connect',
   })
 
   await addressClient.setOAuthData.mutate(authRes)

--- a/apps/passport/app/routes/connect/google/callback.ts
+++ b/apps/passport/app/routes/connect/google/callback.ts
@@ -11,7 +11,7 @@ import {
 import type { OAuthData } from '@proofzero/platform.address/src/types'
 import { NodeType, OAuthAddressType } from '@proofzero/types/address'
 import {
-  getConsoleParams,
+  getAuthzCookieParams,
   getJWTConditionallyFromSession,
 } from '~/session.server'
 
@@ -21,7 +21,7 @@ export const loader: LoaderFunction = async ({
 }: LoaderArgs) => {
   await checkOAuthError(request, context.env)
 
-  const appData = await getConsoleParams(request, context.env)
+  const appData = await getAuthzCookieParams(request, context.env)
 
   const authenticator = initAuthenticator(context.env)
   authenticator.use(getGoogleAuthenticator(context.env))
@@ -53,7 +53,7 @@ export const loader: LoaderFunction = async ({
       context.env,
       appData?.clientId
     ),
-    force: !appData || appData.prompt !== 'connect',
+    force: !appData || appData.rollup_action !== 'connect',
   })
 
   await addressClient.setOAuthData.mutate(authRes)

--- a/apps/passport/app/routes/connect/microsoft/callback.ts
+++ b/apps/passport/app/routes/connect/microsoft/callback.ts
@@ -12,7 +12,7 @@ import {
   checkOAuthError,
 } from '~/utils/authenticate.server'
 import {
-  getConsoleParams,
+  getAuthzCookieParams,
   getJWTConditionallyFromSession,
 } from '~/session.server'
 import cacheImageToCF from '~/utils/cacheImageToCF.server'
@@ -23,7 +23,7 @@ export const loader: LoaderFunction = async ({
 }: LoaderArgs) => {
   await checkOAuthError(request, context.env)
 
-  const appData = await getConsoleParams(request, context.env)
+  const appData = await getAuthzCookieParams(request, context.env)
 
   const authenticator = initAuthenticator(context.env)
   authenticator.use(getMicrosoftStrategy(context.env))
@@ -56,7 +56,7 @@ export const loader: LoaderFunction = async ({
       context.env,
       appData?.clientId
     ),
-    force: !appData || appData.prompt !== 'connect',
+    force: !appData || appData.rollup_action !== 'connect',
   })
 
   return authenticateAddress(
@@ -70,4 +70,4 @@ export const loader: LoaderFunction = async ({
   )
 }
 
-export default () => { }
+export default () => {}

--- a/apps/passport/app/routes/connect/twitter/callback.ts
+++ b/apps/passport/app/routes/connect/twitter/callback.ts
@@ -15,7 +15,7 @@ import {
   checkOAuthError,
 } from '~/utils/authenticate.server'
 import {
-  getConsoleParams,
+  getAuthzCookieParams,
   getJWTConditionallyFromSession,
 } from '~/session.server'
 
@@ -25,7 +25,7 @@ export const loader: LoaderFunction = async ({
 }: LoaderArgs) => {
   await checkOAuthError(request, context.env)
 
-  const appData = await getConsoleParams(request, context.env)
+  const appData = await getAuthzCookieParams(request, context.env)
 
   const authenticator = initAuthenticator(context.env)
   authenticator.use(getTwitterStrategy(context.env))
@@ -52,7 +52,7 @@ export const loader: LoaderFunction = async ({
       context.env,
       appData?.clientId
     ),
-    force: !appData || appData.prompt !== 'connect',
+    force: !appData || appData.rollup_action !== 'connect',
   })
 
   await addressClient.setOAuthData.mutate({

--- a/apps/passport/app/routes/settings.tsx
+++ b/apps/passport/app/routes/settings.tsx
@@ -2,8 +2,8 @@ import { Outlet, useLoaderData } from '@remix-run/react'
 
 import { json } from '@remix-run/cloudflare'
 import {
-  getConsoleParams,
-  getDefaultConsoleParams,
+  getAuthzCookieParams,
+  getDefaultAuthzParams,
   getValidatedSessionContext,
 } from '~/session.server'
 import { Popover } from '@headlessui/react'
@@ -34,7 +34,7 @@ export const links: LinksFunction = () => [
 ]
 
 export const loader: LoaderFunction = async ({ request, context }) => {
-  const passportDefaultAuthzParams = getDefaultConsoleParams(request)
+  const passportDefaultAuthzParams = getDefaultAuthzParams(request)
 
   const { jwt, accountUrn } = await getValidatedSessionContext(
     request,

--- a/apps/passport/app/routes/settings/accounts/disconnect.tsx
+++ b/apps/passport/app/routes/settings/accounts/disconnect.tsx
@@ -4,14 +4,14 @@ import type { ActionFunction } from '@remix-run/cloudflare'
 import { getAddressClient } from '~/platform.server'
 import {
   getValidatedSessionContext,
-  getDefaultConsoleParams,
+  getDefaultAuthzParams,
 } from '~/session.server'
 
 export const action: ActionFunction = async ({ request, context }) => {
   try {
     await getValidatedSessionContext(
       request,
-      getDefaultConsoleParams(request),
+      getDefaultAuthzParams(request),
       context.env,
       context.traceSpan
     )

--- a/apps/passport/app/routes/settings/accounts/index.tsx
+++ b/apps/passport/app/routes/settings/accounts/index.tsx
@@ -34,7 +34,7 @@ import type { AddressURN } from '@proofzero/urns/address'
 export const action: ActionFunction = async ({ request, context }) => {
   const { jwt } = await getValidatedSessionContext(
     request,
-    context.consoleParams,
+    context.authzQueryParams,
     context.env,
     context.traceSpan
   )
@@ -219,7 +219,7 @@ export default function AccountsLayout() {
     }
 
     const qp = new URLSearchParams()
-    qp.append('prompt', 'connect')
+    qp.append('rollup_action', 'connect')
     qp.append('client_id', 'passport')
     qp.append('state', 'skip')
     qp.append('scope', '')

--- a/apps/passport/app/routes/settings/accounts/references.tsx
+++ b/apps/passport/app/routes/settings/accounts/references.tsx
@@ -4,14 +4,14 @@ import type { ActionFunction } from '@remix-run/cloudflare'
 import { AddressUsageDisconnectModel } from '~/components/settings/accounts/DisconnectModal'
 import { getAddressClient } from '~/platform.server'
 import {
-  getDefaultConsoleParams,
+  getDefaultAuthzParams,
   getValidatedSessionContext,
 } from '~/session.server'
 
 export const action: ActionFunction = async ({ request, context }) => {
   await getValidatedSessionContext(
     request,
-    getDefaultConsoleParams(request),
+    getDefaultAuthzParams(request),
     context.env,
     context.traceSpan
   )

--- a/apps/passport/app/routes/settings/accounts/rename.tsx
+++ b/apps/passport/app/routes/settings/accounts/rename.tsx
@@ -1,14 +1,14 @@
 import type { ActionFunction } from '@remix-run/cloudflare'
 import { getAddressClient } from '~/platform.server'
 import {
-  getDefaultConsoleParams,
+  getDefaultAuthzParams,
   getValidatedSessionContext,
 } from '~/session.server'
 
 export const action: ActionFunction = async ({ request, context }) => {
   await getValidatedSessionContext(
     request,
-    getDefaultConsoleParams(request),
+    getDefaultAuthzParams(request),
     context.env,
     context.traceSpan
   )

--- a/apps/passport/app/routes/settings/advanced.tsx
+++ b/apps/passport/app/routes/settings/advanced.tsx
@@ -28,7 +28,7 @@ import { RollupError, ERROR_CODES } from '@proofzero/errors'
 export const action: ActionFunction = async ({ request, context }) => {
   const { jwt, accountUrn } = await getValidatedSessionContext(
     request,
-    context.consoleParams,
+    context.authzQueryParams,
     context.env,
     context.traceSpan
   )

--- a/apps/passport/app/routes/settings/applications/$clientId/revoke.tsx
+++ b/apps/passport/app/routes/settings/applications/$clientId/revoke.tsx
@@ -12,7 +12,7 @@ export const action: ActionFunction = async ({ request, params, context }) => {
 
   const { jwt } = await getValidatedSessionContext(
     request,
-    context.consoleParams,
+    context.authzQueryParams,
     context.env,
     context.traceSpan
   )

--- a/apps/passport/app/routes/settings/applications/$clientId/scopes.tsx
+++ b/apps/passport/app/routes/settings/applications/$clientId/scopes.tsx
@@ -6,7 +6,7 @@ import { BadRequestError } from '@proofzero/errors'
 export const loader: LoaderFunction = async ({ request, params, context }) => {
   const { accountUrn } = await getValidatedSessionContext(
     request,
-    context.consoleParams,
+    context.authzQueryParams,
     context.env,
     context.traceSpan
   )

--- a/apps/passport/app/routes/settings/applications/index.tsx
+++ b/apps/passport/app/routes/settings/applications/index.tsx
@@ -25,7 +25,7 @@ import type { FetcherWithComponents } from '@remix-run/react'
 export const loader: LoaderFunction = async ({ request, context }) => {
   await getValidatedSessionContext(
     request,
-    context.consoleParams,
+    context.authzQueryParams,
     context.env,
     context.traceSpan
   )

--- a/apps/passport/app/session.server.ts
+++ b/apps/passport/app/session.server.ts
@@ -175,8 +175,6 @@ export async function destroyUserSession(
   })
 }
 
-// CONSOLE PARAMS
-
 const getAuthzCookieParamsSessionStorage = (
   env: Env,
   clientId: string = 'last',
@@ -188,7 +186,7 @@ const getAuthzCookieParamsSessionStorage = (
   return createCookieSessionStorage({
     cookie: {
       domain: env.COOKIE_DOMAIN,
-      name: `_rollup_client_params_${clientId}`,
+      name: `_rollup_authz_params_${clientId}`,
       path: '/',
       sameSite: 'lax',
       secure: process.env.NODE_ENV == 'production',

--- a/apps/passport/app/utils/authorize.server.ts
+++ b/apps/passport/app/utils/authorize.server.ts
@@ -121,8 +121,8 @@ export const getDataForScopes = async (
  * checked.
  */
 export function authzParamsMatch(
-  authzCookieParams: ConsoleParams,
-  authzQueryParams: ConsoleParams
+  authzCookieParams: AuthzParams,
+  authzQueryParams: AuthzParams
 ) {
   const scopesMatch = !!(
     authzCookieParams &&
@@ -150,7 +150,7 @@ export function authzParamsMatch(
 
 export async function createAuthzParamCookieAndCreate(
   request: Request,
-  authzParams: ConsoleParams,
+  authzParams: AuthzParams,
   env: Env
 ) {
   let redirectURL

--- a/apps/passport/bindings.d.ts
+++ b/apps/passport/bindings.d.ts
@@ -45,18 +45,23 @@ declare global {
     INTERNAL_DISCORD_OAUTH_CALLBACK_URL: string
   }
 
-  interface ConsoleParams {
-    clientId: string | null
-    redirectUri: string | null
-    scope: string[] | null
-    state: string | null
-    prompt?: string | null
-    login_hint?: string | null
+  interface AuthzParams {
+    clientId: string
+    redirectUri: string
+    scope: string[]
+    state: string
+    prompt?: string
+    login_hint?: string
+    rollup_action?: string
+    rollup_result?: string
   }
+
+  //Same-ish structure, different type name for easier identification
+  type AuthzCookieParams = AuthzParams & { source: 'cookie' }
 }
 declare module '@remix-run/cloudflare' {
   export interface AppLoadContext {
-    consoleParams: ConsoleParams
+    authzQueryParams: AuthzParams
     env: Env
     traceSpan: TraceSpan
   }

--- a/apps/passport/server.ts
+++ b/apps/passport/server.ts
@@ -10,12 +10,15 @@ import * as build from '@remix-run/dev/server-build'
 
 export function parseParams(request: Request) {
   const url = new URL(request.url)
-  const clientId = url.searchParams.get('client_id')
-  const state = url.searchParams.get('state')
-  const redirectUri = url.searchParams.get('redirect_uri')
+  const clientId = url.searchParams.get('client_id') || ''
+  const state = url.searchParams.get('state') || ''
+  const redirectUri = url.searchParams.get('redirect_uri') || ''
   const scope = url.searchParams.get('scope')
-  const prompt = url.searchParams.get('prompt')
-  const login_hint = url.searchParams.get('login_hint')
+  //Optional params get a default value of undefined
+  const prompt = url.searchParams.get('prompt') || undefined
+  const login_hint = url.searchParams.get('login_hint') || undefined
+  const rollup_action = url.searchParams.get('rollup_action') || undefined
+  const rollup_result = url.searchParams.get('rollup_result') || undefined
 
   const decodedScope =
     scope &&
@@ -30,6 +33,8 @@ export function parseParams(request: Request) {
     scope: decodedScope ? decodedScope.split(' ') : [],
     prompt,
     login_hint,
+    rollup_action,
+    rollup_result,
   }
 }
 
@@ -39,7 +44,7 @@ const requestHandler = createRequestHandler({
   getLoadContext: (event) => {
     const traceSpan = (event as TraceableFetchEvent).traceSpan
     return {
-      consoleParams: parseParams(event.request),
+      authzQueryParams: parseParams(event.request),
       env: globalThis as unknown as Env,
       traceSpan,
     }

--- a/packages/design-system/src/hooks/useConnectResult.tsx
+++ b/packages/design-system/src/hooks/useConnectResult.tsx
@@ -7,7 +7,7 @@ export default (
   useEffect(() => {
     const url = new URL(window.location.href)
 
-    const connectResult = url.searchParams.get('connect_result')
+    const connectResult = url.searchParams.get('rollup_result')
     if (connectResult) {
       if (handledMessageTypes.includes(connectResult)) {
         switch (connectResult) {
@@ -35,7 +35,7 @@ export default (
         }
       }
 
-      url.searchParams.delete('connect_result')
+      url.searchParams.delete('rollup_result')
 
       history.replaceState(null, '', url.toString())
     }


### PR DESCRIPTION
### Description

Fixes disappearing `prompt=consent` param for the authorization endpoint. 
Introduces two new params, `rollup_action` and `rollup_result`, so that we don't overload the `prompt` param with our custom actions. 

Also renames consoleParams, both query param and cookies variables/props, to authzParams and authzCookieParams.

### Related Issues

- Closes #2200
- Closes #2072

### Testing

- Ran all authorizataion flows with and without `prompt=consent`. 
- Ran `connect` flow from Passport as well as from authorization screen, to connect a new email.
- Ran a `create` flow for Smart contract wallet.
- Ran a `reconnec` flow by disconnecting my github.
- Ran each of the above flows partially by cancelling them halfway and seeing if we're correctly redirected back to origin site (Passport settings or Authz screen).

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
