### PR TITLE
fix(docs): Correct typo in galaxy api

### DIFF
--- a/docs/reference/galaxy-api.md
+++ b/docs/reference/galaxy-api.md
@@ -215,7 +215,7 @@ const { profile } = await myGeneratedClient.getProfileFromAddress({
 
 #### X-Galaxy-Key Header
 
-This is the API Key that can be found in the dashboard of you [Console](../platform/console/) App and is required to authenticate into the Galaxy API.
+This is the API Key that can be found in the dashboard of your [Console](../platform/console/) App and is required to authenticate into the Galaxy API.
 
 #### Authorization Header
 


### PR DESCRIPTION
### Description

This pull request corrects a minor typo in the documentation. The sentence in question originally read:

"This is the API Key that can be found in the dashboard of ***you*** [Console](../platform/console/) App..."

I have made a change to correct the typo and the sentence now reads:

"This is the API Key that can be found in the dashboard of your [Console](../platform/console/) App..."


### Testing

- [x] Manual

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually)
- [x] I have updated the documentation 
