### PR TITLE
fix(passport): Makes `connected_accounts` claims consistently shaped

### DIFF
--- a/packages/security/persona.ts
+++ b/packages/security/persona.ts
@@ -285,7 +285,7 @@ export async function getClaimValues(
         const edgeResults = await Promise.allSettled(edgePromises)
 
         //Make typescript gods happy
-        type connectedAddressType = { type: string; alias: string }
+        type connectedAddressType = { type: string; identifier: string }
         const isDefined = (
           optionallyDefined: connectedAddressType | undefined
         ): optionallyDefined is connectedAddressType => !!optionallyDefined
@@ -293,7 +293,10 @@ export async function getClaimValues(
         const claimResults = edgeResults
           .map((e) => {
             if (e.status === 'fulfilled')
-              return { type: e.value.rc.addr_type, alias: e.value.qc.alias }
+              return {
+                type: e.value.rc.addr_type,
+                identifier: e.value.qc.alias,
+              }
           })
           .filter(isDefined)
         result = { ...result, connected_accounts: claimResults }


### PR DESCRIPTION
### Description

`connected_accounts` scope claims had different shapes, depending on if the user-selection was ALL or invididual accounts. `{ type, alias }` vs `{ identifier, alias }`. This makes the shape consistent to `{ identifier, alias }`
### Related Issues

- N/A

### Testing

- Test `/userinfo` after authz with `connected_accounts` with selection of ALL
- Test `/userinfo` after authz with `connected_accounts` with selection of individual accounts.

Both produced the same output shape.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
