### PR TITLE
fix(platform): Delete node and session bugfixes after identity delete.

### DIFF
--- a/apps/passport/app/routes/authenticate/$clientId.tsx
+++ b/apps/passport/app/routes/authenticate/$clientId.tsx
@@ -48,23 +48,6 @@ export const loader: LoaderFunction = async ({ request, context, params }) => {
   })
 }
 
-// TODO: update with white label settings
-export const meta: MetaFunction = ({
-  data,
-}: {
-  data: ReturnType<typeof loader>
-}) => ({
-  charset: 'utf-8',
-  title: data?.appProps.name,
-  viewport: 'width=device-width,initial-scale=1',
-  'og:url': data?.appProps.redirectURI,
-  'og:description': 'Identity management for the private web.',
-  'og:image': social,
-  'twitter:card': 'summary_large_image',
-  'twitter:site': '@rollupid_xyz',
-  'twitter:creator': '@rollupid_xyz',
-})
-
 export default () => {
   const { clientId, appProps, rollup_action } = useLoaderData()
 

--- a/apps/passport/app/routes/authenticate/$clientId.tsx
+++ b/apps/passport/app/routes/authenticate/$clientId.tsx
@@ -34,6 +34,7 @@ export const loader: LoaderFunction = async ({ request, context, params }) => {
 
   let rollup_action
   if (
+    cp &&
     cp.rollup_action &&
     ['connect', 'reconnect'].includes(cp?.rollup_action)
   ) {
@@ -54,9 +55,9 @@ export const meta: MetaFunction = ({
   data: ReturnType<typeof loader>
 }) => ({
   charset: 'utf-8',
-  title: data.appProps.name,
+  title: data?.appProps.name,
   viewport: 'width=device-width,initial-scale=1',
-  'og:url': data.appProps.redirectURI,
+  'og:url': data?.appProps.redirectURI,
   'og:description': 'Identity management for the private web.',
   'og:image': social,
   'twitter:card': 'summary_large_image',

--- a/apps/passport/app/routes/signout.tsx
+++ b/apps/passport/app/routes/signout.tsx
@@ -9,7 +9,7 @@ export const loader: LoaderFunction = async ({ request, context }) => {
   const redirectTo = params.get('redirect_uri') || '/'
   const clientId = params.get('client_id') ?? undefined
 
-  return destroyUserSession(
+  return await destroyUserSession(
     request,
     redirectTo,
     context.env,

--- a/apps/passport/app/session.server.ts
+++ b/apps/passport/app/session.server.ts
@@ -301,7 +301,7 @@ export async function getAuthzCookieParams(
       }
     })
     .catch((err) => {
-      console.log('No console params session found')
+      console.log('No authorization cookie params found')
       return null
     })
 }

--- a/platform/access/src/jsonrpc/methods/revokeAppAuthorization.ts
+++ b/platform/access/src/jsonrpc/methods/revokeAppAuthorization.ts
@@ -89,6 +89,10 @@ export const revokeAppAuthorizationMethod: RevokeAppAuthorizationMethod =
       })
     }
 
+    await ctx.edgesClient.deleteNode.mutate({
+      urn: accessURN,
+    })
+
     const accessNode = await initAccessNodeByName(name, ctx.Access)
     await accessNode.class.deleteAll()
   }

--- a/platform/account/src/jsonrpc/methods/deleteAccountNode.ts
+++ b/platform/account/src/jsonrpc/methods/deleteAccountNode.ts
@@ -17,6 +17,7 @@ export const deleteAccountNodeMethod = async ({
   ctx: Context
 }) => {
   if (ctx.accountURN === input.account) {
+    await ctx.edges.deleteNode.mutate({ urn: input.account })
     await ctx.account?.storage.deleteAll()
   } else {
     throw new UnauthorizedError()

--- a/platform/edges/src/db/remove.ts
+++ b/platform/edges/src/db/remove.ts
@@ -24,3 +24,7 @@ export function edge(
     .prepare('DELETE FROM edge WHERE src = ? AND dst = ? AND tag = ?')
     .bind(src, dst, tag)
 }
+
+export function node(g: Graph, urn: AnyURN): D1PreparedStatement {
+  return g.db.prepare('DELETE FROM node WHERE urn = ?').bind(urn)
+}

--- a/platform/edges/src/jsonrpc/methods/deleteNode.ts
+++ b/platform/edges/src/jsonrpc/methods/deleteNode.ts
@@ -1,0 +1,36 @@
+import { Context } from '../../context'
+import * as remove from '../../db/remove'
+import { z } from 'zod'
+import { AnyURNInput } from '@proofzero/platform-middleware/inputValidators'
+import { BadRequestError, InternalServerError } from '@proofzero/errors'
+import { AnyURN } from '@proofzero/urns'
+
+export const DeleteNodeMethodInput = z.object({ urn: AnyURNInput })
+
+export const DeleteNodeMethodOutput = z.object({ deleted: z.boolean() })
+
+export const deleteNodeMethod = async ({
+  input,
+  ctx,
+}: {
+  input: z.infer<typeof DeleteNodeMethodInput>
+  ctx: Context
+}): Promise<z.infer<typeof DeleteNodeMethodOutput>> => {
+  const nodeUrn = input.urn
+  if (!nodeUrn)
+    throw new BadRequestError({
+      message: 'No URN specified for deleteNode call',
+    })
+  const statement = remove.node(ctx.graph, nodeUrn)
+  const deleted = await ctx.graph.db.batch([statement])
+
+  if (
+    deleted.length > 1 ||
+    (deleted.length === 1 && deleted[0].meta && deleted[0].meta.changes > 1)
+  )
+    //This should never happen, but adding just in case
+    throw new InternalServerError({
+      message: 'Node deletion returned more than one result.',
+    })
+  return { deleted: deleted[0].meta.changes === 1 }
+}

--- a/platform/edges/src/jsonrpc/router.ts
+++ b/platform/edges/src/jsonrpc/router.ts
@@ -34,6 +34,11 @@ import {
   UpdateNodeCompsMethodInput,
   UpdateNodeCompsMethodOutput,
 } from './methods/updateNodeComps'
+import {
+  deleteNodeMethod,
+  DeleteNodeMethodInput,
+  DeleteNodeMethodOutput,
+} from './methods/deleteNode'
 
 const t = initTRPC.context<Context>().create({ errorFormatter })
 
@@ -44,6 +49,12 @@ export const appRouter = t.router({
     .input(FindNodeMethodInput)
     .output(FindNodeMethodOutput)
     .query(findNodeMethod),
+  deleteNode: t.procedure
+    .use(LogUsage)
+    .use(Analytics)
+    .input(DeleteNodeMethodInput)
+    .output(DeleteNodeMethodOutput)
+    .mutation(deleteNodeMethod),
   updateNode: t.procedure
     .use(LogUsage)
     .use(Analytics)

--- a/platform/starbase/src/jsonrpc/methods/deleteApp.ts
+++ b/platform/starbase/src/jsonrpc/methods/deleteApp.ts
@@ -33,6 +33,9 @@ export const deleteApp = async ({
     dst: appURN,
     tag: EDGE_APPLICATION,
   })
+  await ctx.edges.deleteNode.mutate({
+    urn: appURN,
+  })
   await appDO.class.delete()
 
   console.log(`Deleted app ${input.clientId} from account ${ctx.accountURN}`)


### PR DESCRIPTION
### Description

- Adds functionality to delete nodes in edges database.
- Adds node-deletion for account disconnect, app authz revocation and identity delete.
- Fixes issue with OG MetaFunction that was causing errors
- Addresses session invalidation after identity delete.

### Related Issues

- Closes #2216

### Testing

- Multiple passes through account and identity deletion. Same with application authz revocation.
- Refreshing "Continue with" screen after identity deletion.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
