### PR TITLE
chore(profile): exclude `extraParams` in the session cookie

### DIFF
--- a/apps/profile/app/utils/session.server.tsx
+++ b/apps/profile/app/utils/session.server.tsx
@@ -94,7 +94,7 @@ export const getRollupAuthenticator = () => {
         refreshToken: JSON.stringify(
           await encryptSession(sessionKey, refreshToken)
         ),
-        extraParams,
+        extraParams: {},
       }
     }
   )


### PR DESCRIPTION
---

### Description

The `id_token` and `token_type` are not used in the application. The `id_token`
takes a considerable amount of space in the cookie storage.

### Related Issues

- Closes #2239

### Testing

- [x] Manual

The authenticated routes work as expected.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [x] I have updated the documentation (if necessary)