### PR TITLE
fix(passport): fix redirect URL when the wallet account is already connected

### DIFF
--- a/apps/passport/app/routes/connect/$address/sign.tsx
+++ b/apps/passport/app/routes/connect/$address/sign.tsx
@@ -6,6 +6,7 @@ import { AddressURNSpace } from '@proofzero/urns/address'
 import { generateHashedIDRef } from '@proofzero/urns/idref'
 import { CryptoAddressType, NodeType } from '@proofzero/types/address'
 import { getAuthzCookieParams, getUserSession } from '../../../session.server'
+import { getRedirectURL } from '../../../utils/authenticate.server'
 
 import { signMessageTemplate } from '@proofzero/design-system/src/atoms/buttons/connect-button/ConnectButton'
 
@@ -67,7 +68,7 @@ export const action: ActionFunction = async ({ request, context, params }) => {
   })
 
   if (appData?.rollup_action === 'connect' && existing) {
-    return redirect(`${appData.redirectUri}?rollup_result=ALREADY_CONNECTED`)
+    return redirect(getRedirectURL(appData, 'ALREADY_CONNECTED'))
   }
 
   // TODO: handle the error case

--- a/apps/passport/app/utils/authenticate.server.ts
+++ b/apps/passport/app/utils/authenticate.server.ts
@@ -91,7 +91,10 @@ export const authenticateAddress = async (
   }
 }
 
-const getRedirectURL = (appData: AuthzParams, result: string = 'SUCCESS') => {
+export const getRedirectURL = (
+  appData: AuthzParams,
+  result: string = 'SUCCESS'
+) => {
   let redirectURL = '/authorize'
   const authAppId = appData.clientId
   const authRedirectUri = appData.redirectUri


### PR DESCRIPTION
---

### Description

A wallet account that is already connected should redirect back properly.

### Related Issues

- Closes #2258

### Testing

- [x] Manual

Also, confirmed it doesn't prematurely redirect back to example-nextjs
application.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [x] I have updated the documentation (if necessary)