### PR TITLE
fix(passport): App data error in Passport settings

### DIFF
--- a/apps/passport/app/routes/settings.tsx
+++ b/apps/passport/app/routes/settings.tsx
@@ -13,6 +13,7 @@ import appleIcon from '~/assets/apple-touch-icon.png'
 import icon32 from '~/assets/favicon-32x32.png'
 import icon16 from '~/assets/favicon-16x16.png'
 import faviconSvg from '~/assets/favicon.svg'
+import warningImg from '~/assets/warning.svg'
 
 import {
   getAccountClient,
@@ -68,15 +69,26 @@ export const loader: LoaderFunction = async ({ request, context }) => {
   const awaitedResults = await Promise.all([
     Promise.all(
       apps.map(async (a) => {
-        const { name, iconURL } = await starbaseClient.getAppPublicProps.query({
-          clientId: a.clientId,
-        })
-
-        return {
-          clientId: a.clientId,
-          icon: iconURL,
-          title: name,
-          timestamp: a.timestamp,
+        try {
+          const { name, iconURL } =
+            await starbaseClient.getAppPublicProps.query({
+              clientId: a.clientId,
+            })
+          return {
+            clientId: a.clientId,
+            icon: iconURL,
+            title: name,
+            timestamp: a.timestamp,
+          }
+        } catch (e) {
+          //We swallow the error and move on to next app
+          console.error(e)
+          return {
+            clientId: a.clientId,
+            icon: warningImg,
+            title: 'Application data error',
+            timestamp: a.timestamp,
+          }
         }
       })
     ),


### PR DESCRIPTION
### Description

Fix for app data error, causing Passport Settings not to load. This swallows the app-specific error and allows the user to recover.

### Related Issues

- N/A

### Testing

Deployed to dev where my user couldn't log on to Passport settings before this fix due to error. No error after fix.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
