### PR TITLE
bug(passport): Overlap in long titles for "Continue with" button

### DIFF
--- a/packages/design-system/src/templates/authentication/AccountSelect.tsx
+++ b/packages/design-system/src/templates/authentication/AccountSelect.tsx
@@ -77,6 +77,7 @@ export default ({
                   )}
                 </>
               }
+              Addon={<div className="w-14"></div>}
               text={userProfile.displayName}
             />
 


### PR DESCRIPTION
### Description

- Added an invisible element with set width to provide the padding

### Related Issues

- Closes #2228 

### Testing

- Visual

### Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [ ] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
