### PR TITLE
chore(platform): JWKS-based JWT verification & Galaxy scopes support.

### DIFF
--- a/apps/console/app/root.tsx
+++ b/apps/console/app/root.tsx
@@ -42,12 +42,8 @@ import createStarbaseClient from '@proofzero/platform-clients/starbase'
 import createAccountClient from '@proofzero/platform-clients/account'
 import { getAuthzHeaderConditionallyFromToken } from '@proofzero/utils'
 import { generateTraceContextHeaders } from '@proofzero/platform-middleware/trace'
-
 import type { AccountURN } from '@proofzero/urns/account'
-
 import { NonceContext } from '@proofzero/design-system/src/atoms/contexts/nonce-context'
-import { InternalServerError } from '@proofzero/errors'
-
 import useTreeshakeHack from '@proofzero/design-system/src/hooks/useTreeshakeHack'
 import { getRollupReqFunctionErrorWrapper } from '@proofzero/utils/errors'
 

--- a/apps/console/app/routes/apps/$clientId/team.tsx
+++ b/apps/console/app/routes/apps/$clientId/team.tsx
@@ -11,7 +11,7 @@ import { DocumentationBadge } from '~/components/DocumentationBadge'
 import { redirect } from '@remix-run/cloudflare'
 import useConnectResult from '@proofzero/design-system/src/hooks/useConnectResult'
 import { requireJWT } from '~/utilities/session.server'
-import { checkToken } from '@proofzero/utils/token'
+import { verifyToken } from '@proofzero/utils/token'
 
 import createAccountClient from '@proofzero/platform-clients/account'
 import { getAuthzHeaderConditionallyFromToken } from '@proofzero/utils'
@@ -38,9 +38,8 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
     const clientId = params.clientId as string
 
     const jwt = await requireJWT(request)
-    const payload = checkToken(jwt)
+    const payload = await verifyToken(jwt, JWKS_INTERNAL_URL_BASE)
     const accountURN = payload.sub as AccountURN
-
     const accountClient = createAccountClient(Account, {
       ...getAuthzHeaderConditionallyFromToken(jwt),
       ...generateTraceContextHeaders(context.traceSpan),

--- a/apps/console/app/utilities/session.server.tsx
+++ b/apps/console/app/utilities/session.server.tsx
@@ -10,7 +10,7 @@ import { createCookie, redirect } from '@remix-run/cloudflare'
 import { decryptSession } from '@proofzero/utils/session'
 
 import {
-  checkToken,
+  verifyToken,
   ExpiredTokenError,
   InvalidTokenError,
 } from '@proofzero/utils/token'
@@ -72,7 +72,7 @@ export async function requireJWT(request: Request) {
   const jwt = await getUserSession(request)
 
   try {
-    checkToken(jwt)
+    await verifyToken(jwt, JWKS_INTERNAL_URL_BASE)
     return jwt
   } catch (error) {
     switch (error) {
@@ -89,6 +89,8 @@ export async function requireJWT(request: Request) {
         qp.append('state', 'skip')
 
         throw redirect(`${PASSPORT_URL}/authorize?${qp.toString()}`)
+      default:
+        throw error
     }
   }
 }

--- a/apps/console/bindings.d.ts
+++ b/apps/console/bindings.d.ts
@@ -7,6 +7,7 @@ declare global {
   const SECRET_SESSION_KEY: string
   const COOKIE_DOMAIN: string
   const PASSPORT_URL: string
+  const JWKS_INTERNAL_URL_BASE: string
   const STORAGE_NAMESPACE: string
   const INTERNAL_GOOGLE_ANALYTICS_TAG: string
   const PROFILE_APP_URL: string

--- a/apps/console/wrangler.toml
+++ b/apps/console/wrangler.toml
@@ -36,6 +36,7 @@ STORAGE_NAMESPACE = "console"
 INTERNAL_GOOGLE_ANALYTICS_TAG = "G-NHNH4KRWC3"
 PROFILE_APP_URL = "http://localhost:10003"
 COOKIE_DOMAIN = "localhost"
+JWKS_INTERNAL_URL_BASE = "http://127.0.0.1:10001/.well-known/jwks.json"
 
 # Site
 # -----------------------------------------------------------------------------
@@ -77,6 +78,8 @@ COOKIE_DOMAIN = "rollup.id"
 STORAGE_NAMESPACE = "console"
 INTERNAL_GOOGLE_ANALYTICS_TAG = "G-NHNH4KRWC3"
 PROFILE_APP_URL = "https://my-dev.rollup.id"
+JWKS_INTERNAL_URL_BASE = "https://passport-dev.pz3r0.com/.well-known/jwks.json"
+
 
 # Environment: next
 # -----------------------------------------------------------------------------
@@ -107,6 +110,8 @@ COOKIE_DOMAIN = "rollup.id"
 STORAGE_NAMESPACE = "console"
 INTERNAL_GOOGLE_ANALYTICS_TAG = "G-X7ZN16M4NB"
 PROFILE_APP_URL = "https://my-next.rollup.id"
+JWKS_INTERNAL_URL_BASE = "https://passport-next.pz3r0.com/.well-known/jwks.json"
+
 
 # Environment: current
 # -----------------------------------------------------------------------------
@@ -138,3 +143,4 @@ COOKIE_DOMAIN = "rollup.id"
 STORAGE_NAMESPACE = "console"
 INTERNAL_GOOGLE_ANALYTICS_TAG = "G-675VJMWSRY"
 PROFILE_APP_URL = "https://my.rollup.id"
+JWKS_INTERNAL_URL_BASE = "https://passport.pz3r0.com/.well-known/jwks.json"

--- a/apps/passport/app/routes/[.]well-known/jwks[.]json.ts
+++ b/apps/passport/app/routes/[.]well-known/jwks[.]json.ts
@@ -1,16 +1,34 @@
-import {
-  JsonError,
-  getRollupReqFunctionErrorWrapper,
-} from '@proofzero/utils/errors'
+import { BadRequestError } from '@proofzero/errors'
+import { getRollupReqFunctionErrorWrapper } from '@proofzero/utils/errors'
 import { json } from '@remix-run/cloudflare'
 import type { LoaderFunction } from '@remix-run/cloudflare'
 
 import { getAccessClient } from '~/platform.server'
 
 export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
-  async ({ context }) => {
+  async ({ request, context }) => {
     const client = getAccessClient(context.env, context.traceSpan)
-    const jwks = await client.getJWKS.query()
+
+    const requestUrl = new URL(request.url)
+    const optionalParams = requestUrl.searchParams
+    const issuerDomain = optionalParams.get('issuer_domain')
+    let jwks
+
+    if (issuerDomain) {
+      const host = requestUrl.hostname
+      //This is where the logic for custom domain JWKS retrieval comes in
+      //For now we only implement Passport
+      if (issuerDomain === host) {
+        jwks = await client.getJWKS.query()
+      } else {
+        throw new BadRequestError({ message: 'Invalid issuer_domain provided' })
+      }
+    } else {
+      //This is the regular (external) call made against the issuer domain directly
+      //This will also need to be modified as part of custom domain implementation
+      //to take current origin as a parameter
+      jwks = await client.getJWKS.query()
+    }
     return json(jwks)
   }
 )

--- a/apps/passport/app/session.server.ts
+++ b/apps/passport/app/session.server.ts
@@ -9,9 +9,9 @@ import * as jose from 'jose'
 import type { JWTPayload } from 'jose'
 
 import {
-  checkToken,
   ExpiredTokenError,
   InvalidTokenError,
+  verifyToken,
 } from '@proofzero/utils/token'
 
 import { encryptSession, decryptSession } from '@proofzero/utils/session'
@@ -302,7 +302,7 @@ export async function getValidatedSessionContext(
   )
 
   try {
-    const payload = checkToken(jwt)
+    const payload = await verifyToken(jwt, env.JWKS_INTERNAL_URL_BASE)
     const accountClient = getAccountClient(jwt, env, traceSpan)
     if (
       !AccountURNSpace.is(payload.sub!) ||

--- a/apps/passport/bindings.d.ts
+++ b/apps/passport/bindings.d.ts
@@ -19,6 +19,7 @@ declare global {
     PASSPORT_REDIRECT_URL: string
     APIKEY_ALCHEMY_PUBLIC: string
     REMIX_DEV_SERVER_WS_PORT: number
+    JWKS_INTERNAL_URL_BASE: string
 
     INTERNAL_GOOGLE_ANALYTICS_TAG: string
 

--- a/apps/passport/wrangler.toml
+++ b/apps/passport/wrangler.toml
@@ -38,6 +38,8 @@ INTERNAL_MICROSOFT_OAUTH_CALLBACK_URL = "http://localhost:10001/connect/microsof
 INTERNAL_APPLE_OAUTH_CALLBACK_URL = "http://localhost:10001/connect/apple/callback"
 INTERNAL_DISCORD_OAUTH_CALLBACK_URL = "http://localhost:10001/connect/discord/callback"
 INTERNAL_GOOGLE_ANALYTICS_TAG = "G-NHNH4KRWC3"
+JWKS_INTERNAL_URL_BASE = "http://127.0.0.1:10001/.well-known/jwks.json"
+
 
 [env.dev]
 routes = [
@@ -65,6 +67,7 @@ INTERNAL_APPLE_OAUTH_CALLBACK_URL = "https://passport-dev.rollup.id/connect/appl
 INTERNAL_MICROSOFT_OAUTH_CALLBACK_URL = "https://passport-dev.rollup.id/connect/microsoft/callback"
 INTERNAL_DISCORD_OAUTH_CALLBACK_URL = "https://passport-dev.rollup.id/connect/discord/callback"
 INTERNAL_GOOGLE_ANALYTICS_TAG = "G-NHNH4KRWC3"
+JWKS_INTERNAL_URL_BASE = "https://passport-dev.pz3r0.com/.well-known/jwks.json"
 
 [env.next]
 routes = [
@@ -91,6 +94,7 @@ INTERNAL_APPLE_OAUTH_CALLBACK_URL = "https://passport-next.rollup.id/connect/app
 INTERNAL_MICROSOFT_OAUTH_CALLBACK_URL = "https://passport-next.rollup.id/connect/microsoft/callback"
 INTERNAL_DISCORD_OAUTH_CALLBACK_URL = "https://passport-next.rollup.id/connect/discord/callback"
 INTERNAL_GOOGLE_ANALYTICS_TAG = "G-X7ZN16M4NB"
+JWKS_INTERNAL_URL_BASE = "https://passport-next.pz3r0.com/.well-known/jwks.json"
 
 [env.next.build]
 command = "yarn build"
@@ -120,6 +124,7 @@ INTERNAL_APPLE_OAUTH_CALLBACK_URL = "https://passport.rollup.id/connect/apple/ca
 INTERNAL_MICROSOFT_OAUTH_CALLBACK_URL = "https://passport.rollup.id/connect/microsoft/callback"
 INTERNAL_DISCORD_OAUTH_CALLBACK_URL = "https://passport.rollup.id/connect/discord/callback"
 INTERNAL_GOOGLE_ANALYTICS_TAG = "G-675VJMWSRY"
+JWKS_INTERNAL_URL_BASE = "https://passport.pz3r0.com/.well-known/jwks.json"
 
 [env.current.build]
 command = "yarn build"

--- a/apps/profile/app/helpers/profile.ts
+++ b/apps/profile/app/helpers/profile.ts
@@ -7,7 +7,6 @@ import {
 import type { AddressURN } from '@proofzero/urns/address'
 import { getAuthzHeaderConditionallyFromToken } from '@proofzero/utils'
 import { getGalaxyClient } from './clients'
-import { imageFromAddressType } from './icons'
 import type { FullProfile } from '../types'
 import type { AccountURN } from '@proofzero/urns/account'
 import type { TraceSpan } from '@proofzero/platform-middleware/trace'
@@ -18,15 +17,11 @@ import { GetAddressProfilesQuery } from '@proofzero/galaxy-client'
 export const getAccountProfile = async (
   {
     accountURN,
-    jwt,
   }: {
     accountURN: AccountURN
-    jwt?: string
   },
   traceSpan: TraceSpan
 ) => {
-  // note: jwt is only important for setting profile in profile account settings
-
   const profile = await ProfileKV.get<FullProfile>(accountURN, 'json')
 
   if (profile && profile.gallery)

--- a/apps/profile/app/routes/$type.$address.tsx
+++ b/apps/profile/app/routes/$type.$address.tsx
@@ -85,7 +85,7 @@ export const loader: LoaderFunction = async ({ request, params, context }) => {
   try {
     jwt = await getAccessToken(request)
 
-    profile = await getAccountProfile({ jwt, accountURN }, context.traceSpan)
+    profile = await getAccountProfile({ accountURN }, context.traceSpan)
 
     if (!profile) {
       throw json({ message: 'Profile could not be resolved' }, { status: 404 })

--- a/apps/profile/global.d.ts
+++ b/apps/profile/global.d.ts
@@ -10,6 +10,7 @@ declare global {
   const PASSPORT_AUTH_URL: string
   const PASSPORT_TOKEN_URL: string
   const INTERNAL_GOOGLE_ANALYTICS_TAG: string
+  const JWKS_INTERNAL_URL_BASE: string
 
   const PROFILE_CLIENT_ID: string
   const PROFILE_CLIENT_SECRET: string

--- a/apps/profile/wrangler.toml
+++ b/apps/profile/wrangler.toml
@@ -43,6 +43,7 @@ INTERNAL_GOOGLE_ANALYTICS_TAG = "G-NHNH4KRWC3"
 PROFILE_VERSION = 1
 ALCHEMY_ETH_NETWORK = "mainnet"
 ALCHEMY_POLYGON_NETWORK = "mainnet"
+JWKS_INTERNAL_URL_BASE = "http://127.0.0.1:10001/.well-known/jwks.json"
 
 [site]
 bucket = "./public"
@@ -86,6 +87,7 @@ INTERNAL_GOOGLE_ANALYTICS_TAG = "G-NHNH4KRWC3"
 PROFILE_VERSION = 1
 ALCHEMY_ETH_NETWORK = "mainnet"
 ALCHEMY_POLYGON_NETWORK = "mainnet"
+JWKS_INTERNAL_URL_BASE = "https://passport-dev.pz3r0.com/.well-known/jwks.json"
 
 # next (staging)
 # ------------------------------------------------------------------------------
@@ -121,6 +123,8 @@ INTERNAL_GOOGLE_ANALYTICS_TAG = "G-X7ZN16M4NB"
 PROFILE_VERSION = 1
 ALCHEMY_ETH_NETWORK = "mainnet"
 ALCHEMY_POLYGON_NETWORK = "mainnet"
+JWKS_INTERNAL_URL_BASE = "https://passport-next.pz3r0.com/.well-known/jwks.json"
+
 
 # current (production)
 # ------------------------------------------------------------------------------
@@ -154,3 +158,4 @@ INTERNAL_GOOGLE_ANALYTICS_TAG = "G-675VJMWSRY"
 PROFILE_VERSION = 1
 ALCHEMY_ETH_NETWORK = "mainnet"
 ALCHEMY_POLYGON_NETWORK = "mainnet"
+JWKS_INTERNAL_URL_BASE = "https://passport.pz3r0.com/.well-known/jwks.json"

--- a/packages/platform-middleware/jwt.ts
+++ b/packages/platform-middleware/jwt.ts
@@ -2,7 +2,7 @@ import { RollupError } from '@proofzero/errors'
 import type { AccountURN } from '@proofzero/urns/account'
 import { AccountURNSpace } from '@proofzero/urns/account'
 import { getAuthzTokenFromReq } from '@proofzero/utils'
-import { checkToken } from '@proofzero/utils/token'
+import { verifyToken } from '@proofzero/utils/token'
 
 import { BaseMiddlewareFunction } from './types'
 
@@ -20,10 +20,14 @@ export const AuthorizationTokenFromHeader: BaseMiddlewareFunction<{
 
 export const ValidateJWT: BaseMiddlewareFunction<{
   token?: string
-}> = ({ ctx, next }) => {
+  JWKS_INTERNAL_URL_BASE: string
+}> = async ({ ctx, next }) => {
   if (ctx.token) {
     try {
-      const { sub: subject } = checkToken(ctx.token)
+      const { sub: subject } = await verifyToken(
+        ctx.token,
+        ctx.JWKS_INTERNAL_URL_BASE
+      )
       if (subject && AccountURNSpace.is(subject)) {
         return next({
           ctx: {

--- a/packages/utils/errors.ts
+++ b/packages/utils/errors.ts
@@ -42,6 +42,9 @@ export function getRollupReqFunctionErrorWrapper(
       const result = await reqFunction(args)
       return result
     } catch (e) {
+      //Needed for when we throw redirects
+      if (e instanceof Response) return e as Response
+
       const error = getErrorCause(e) as Error
       const { stack, ...otherProps } = error
       const traceparent = context.traceSpan

--- a/packages/utils/token.ts
+++ b/packages/utils/token.ts
@@ -21,7 +21,7 @@ export const verifyToken: VerifyTokenFunction = async (
   jwksInternalUrlBase: string
 ) => {
   try {
-    let cache = caches.default
+    const cache = caches.default
     const jwtHeader = jose.decodeProtectedHeader(token)
     const jwtPayload = jose.decodeJwt(token)
     if (!jwtPayload.iss || !jwtHeader.kid) throw InvalidTokenError

--- a/platform/access/src/context.ts
+++ b/platform/access/src/context.ts
@@ -38,6 +38,7 @@ interface CreateInnerContextOptions
   accountURN?: AccountURN
   SECRET_JWK_CURRENT_KID: string
   SECRET_JWKS: string
+  JWKS_INTERNAL_URL_BASE: string
 }
 /**
  * Inner context. Will always be available in your procedures, in contrast to the outer context.

--- a/platform/access/src/jsonrpc/methods/getUserInfo.ts
+++ b/platform/access/src/jsonrpc/methods/getUserInfo.ts
@@ -18,6 +18,7 @@ import {
   userClaimsFormatter,
 } from '@proofzero/security/persona'
 import { PersonaData } from '@proofzero/types/application'
+import { verifyToken } from '@proofzero/utils/token'
 
 export const GetUserInfoInput = z.object({
   access_token: z.string(),
@@ -33,7 +34,10 @@ export const getUserInfoMethod = async ({
   ctx: Context
 }): Promise<z.infer<typeof GetUserInfoOutput>> => {
   const token = input.access_token
-  const jwt = decodeJwt(token) as AccessJWTPayload
+  const jwt = (await verifyToken(
+    token,
+    ctx.JWKS_INTERNAL_URL_BASE
+  )) as AccessJWTPayload
   const account = jwt.sub
   const [clientId] = jwt.aud
   const scope = jwt.scope.split(' ')

--- a/platform/access/src/types.ts
+++ b/platform/access/src/types.ts
@@ -12,6 +12,7 @@ export interface Environment {
   Address: Fetcher
   SECRET_JWK_CURRENT_KID: string
   SECRET_JWKS: string
+  JWKS_INTERNAL_URL_BASE: string
 }
 
 export type AuthorizationParameters = {

--- a/platform/access/wrangler.toml
+++ b/platform/access/wrangler.toml
@@ -22,10 +22,16 @@ analytics_engine_datasets = [
 
 unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
+[vars]
+JWKS_INTERNAL_URL_BASE = 'http://127.0.0.1:10001/.well-known/jwks.json'
+
 [dev]
 port = 10101
 inspector_port = 11101
 local_protocol = "http"
+
+[env.dev.vars]
+JWKS_INTERNAL_URL_BASE = "https://passport-dev.pz3r0.com/.well-known/jwks.json"
 
 [env.dev]
 durable_objects.bindings = [
@@ -45,6 +51,9 @@ analytics_engine_datasets = [
 
 unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
+[env.next.vars]
+JWKS_INTERNAL_URL_BASE = "https://passport-next.pz3r0.com/.well-known/jwks.json"
+
 [env.next]
 durable_objects.bindings = [
   { name = "Access", class_name = "Access" },
@@ -62,6 +71,9 @@ analytics_engine_datasets = [
 ]
 
 unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
+
+[env.current.vars]
+JWKS_INTERNAL_URL_BASE = "https://passport.pz3r0.com/.well-known/jwks.json"
 
 [env.current]
 durable_objects.bindings = [

--- a/platform/account/src/context.ts
+++ b/platform/account/src/context.ts
@@ -21,6 +21,8 @@ interface CreateInnerContextOptions
   Analytics: AnalyticsEngineDataset
   ServiceDeploymentMetadata: DeploymentMetadata
   account?: DurableObjectStubProxy<Account>
+  JWKS_INTERNAL_URL_BASE: string
+
   // accountURN?: AccountURN
 }
 /**

--- a/platform/account/src/types.ts
+++ b/platform/account/src/types.ts
@@ -9,6 +9,7 @@ export interface Environment {
   Edges: Fetcher
   Analytics: AnalyticsEngineDataset
   ServiceDeploymentMetadata: DeploymentMetadata
+  JWKS_INTERNAL_URL_BASE: string
 }
 
 // TODO: move to types packages

--- a/platform/account/wrangler.toml
+++ b/platform/account/wrangler.toml
@@ -22,10 +22,16 @@ analytics_engine_datasets = [
 
 unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
+[vars]
+JWKS_INTERNAL_URL_BASE = 'http://127.0.0.1:10001/.well-known/jwks.json'
+
 [dev]
 port = 10201
 inspector_port = 11201
 local_protocol = "http"
+
+[env.dev.vars]
+JWKS_INTERNAL_URL_BASE = "https://passport-dev.pz3r0.com/.well-known/jwks.json"
 
 [env.dev]
 durable_objects.bindings = [{ name = "Account", class_name = "Account" }]
@@ -37,6 +43,9 @@ analytics_engine_datasets = [
 
 unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
+[env.next.vars]
+JWKS_INTERNAL_URL_BASE = "https://passport-next.pz3r0.com/.well-known/jwks.json"
+
 [env.next]
 durable_objects.bindings = [{ name = "Account", class_name = "Account" }]
 services = [{ binding = "Edges", service = "edges-next" }]
@@ -46,6 +55,9 @@ analytics_engine_datasets = [
 ]
 
 unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
+
+[env.current.vars]
+JWKS_INTERNAL_URL_BASE = "https://passport.pz3r0.com/.well-known/jwks.json"
 
 [env.current]
 durable_objects.bindings = [{ name = "Account", class_name = "Account" }]

--- a/platform/address/wrangler.toml
+++ b/platform/address/wrangler.toml
@@ -27,7 +27,7 @@ MAX_ATTEMPTS = 5
 DELAY_BETWEEN_REGENERATION_ATTEMPTS_IN_MS = 2_000
 REGENERATION_COOLDOWN_PERIOD_IN_MS = 30_000
 MAX_ATTEMPTS_TIME_PERIOD_IN_MS = 300_000
-
+JWKS_INTERNAL_URL_BASE = "http://127.0.0.1:10001/.well-known/jwks.json"
 
 [dev]
 port = 10102
@@ -81,6 +81,7 @@ MAX_ATTEMPTS = 5
 DELAY_BETWEEN_REGENERATION_ATTEMPTS_IN_MS = 2_000
 REGENERATION_COOLDOWN_PERIOD_IN_MS = 30_000
 MAX_ATTEMPTS_TIME_PERIOD_IN_MS = 300_000
+JWKS_INTERNAL_URL_BASE = "https://passport-dev.pz3r0.com/.well-known/jwks.json"
 
 [env.next]
 durable_objects.bindings = [{ name = "Address", class_name = "Address" }]
@@ -108,6 +109,7 @@ MAX_ATTEMPTS = 5
 DELAY_BETWEEN_REGENERATION_ATTEMPTS_IN_MS = 30_000
 REGENERATION_COOLDOWN_PERIOD_IN_MS = 600_000
 MAX_ATTEMPTS_TIME_PERIOD_IN_MS = 300_000
+JWKS_INTERNAL_URL_BASE = "https://passport-next.pz3r0.com/.well-known/jwks.json"
 
 [env.current]
 durable_objects.bindings = [{ name = "Address", class_name = "Address" }]
@@ -134,3 +136,4 @@ MAX_ATTEMPTS = 5
 DELAY_BETWEEN_REGENERATION_ATTEMPTS_IN_MS = 30_000
 REGENERATION_COOLDOWN_PERIOD_IN_MS = 600_000
 MAX_ATTEMPTS_TIME_PERIOD_IN_MS = 300_000
+JWKS_INTERNAL_URL_BASE = "https://passport.pz3r0.com/.well-known/jwks.json"

--- a/platform/galaxy/src/env.ts
+++ b/platform/galaxy/src/env.ts
@@ -15,6 +15,7 @@ export default interface Env {
   Address: Fetcher
   Starbase: Fetcher
   Access: Fetcher
+  JWKS_INTERNAL_URL_BASE: string
 }
 
 export const required = ['Account', 'Address', 'Starbase', 'Access']

--- a/platform/galaxy/src/schema/resolvers/account.ts
+++ b/platform/galaxy/src/schema/resolvers/account.ts
@@ -10,7 +10,6 @@ import {
   validateApiKey,
   logAnalytics,
   getConnectedAddresses,
-  temporaryConvertToPublic,
   requestLogging,
 } from './utils'
 
@@ -21,10 +20,7 @@ import { ResolverContext } from './common'
 import { PlatformAddressURNHeader } from '@proofzero/types/headers'
 import { getAuthzHeaderConditionallyFromToken } from '@proofzero/utils'
 import type { AccountURN } from '@proofzero/urns/account'
-import {
-  generateTraceContextHeaders,
-  TraceSpan,
-} from '@proofzero/packages/platform-middleware/trace'
+import { generateTraceContextHeaders } from '@proofzero/packages/platform-middleware/trace'
 
 const accountResolvers: Resolvers = {
   Query: {
@@ -158,28 +154,15 @@ const ProfileResolverComposition = {
   'Query.profile': [
     requestLogging(),
     setupContext(),
-    validateApiKey(),
-    logAnalytics(),
-  ],
-  'Query.authorizedApps': [
-    requestLogging(),
-    setupContext(),
+    isAuthorized('profile'),
     validateApiKey(),
     logAnalytics(),
   ],
   'Query.connectedAddresses': [
     requestLogging(),
     setupContext(),
+    // isAuthorized('connected_accounts'),
     validateApiKey(),
-    logAnalytics(),
-    temporaryConvertToPublic(),
-  ],
-
-  'Mutation.disconnectAddress': [
-    requestLogging(),
-    setupContext(),
-    validateApiKey(),
-    isAuthorized(),
     logAnalytics(),
   ],
 }

--- a/platform/galaxy/src/schema/resolvers/address.ts
+++ b/platform/galaxy/src/schema/resolvers/address.ts
@@ -179,24 +179,29 @@ const addressResolvers: Resolvers = {
 
 // TODO: add address middleware
 const AddressResolverComposition = {
-  'Query.account': [requestLogging(), setupContext(), validateApiKey()],
-  'Query.addressProfile': [requestLogging(), setupContext(), validateApiKey()],
-  'Query.addressProfiles': [requestLogging(), setupContext(), validateApiKey()],
-  'Mutation.updateAddressNickname': [
+  'Query.account': [
     requestLogging(),
     setupContext(),
+    isAuthorized('profile'),
     validateApiKey(),
-    isAuthorized(),
   ],
-  'Mutation.updateConnectedAddressesProperties': [
+
+  'Query.addressProfile': [
     requestLogging(),
     setupContext(),
+    isAuthorized('profile'),
     validateApiKey(),
-    isAuthorized(),
+  ],
+  'Query.addressProfiles': [
+    requestLogging(),
+    setupContext(),
+    isAuthorized('connected_accounts'),
+    validateApiKey(),
   ],
   'Mutation.registerSessionKey': [
     requestLogging(),
     setupContext(),
+    isAuthorized('erc_4337'),
     validateApiKey(),
   ],
 }

--- a/platform/galaxy/src/schema/resolvers/app.ts
+++ b/platform/galaxy/src/schema/resolvers/app.ts
@@ -53,20 +53,8 @@ const appResolvers: Resolvers = {
 }
 
 const AppResolverComposition = {
-  'Query.scopes': [
-    requestLogging(),
-    setupContext(),
-    validateApiKey(),
-    isAuthorized(),
-    logAnalytics(),
-  ],
-  'Mutation.revokeAppAuthorization': [
-    requestLogging(),
-    setupContext(),
-    validateApiKey(),
-    isAuthorized(),
-    logAnalytics(),
-  ],
+  //Leaving this here in case we want to (securely) expose these resolvers
+  //through a scope later
 }
 
 export default composeResolvers(appResolvers, AppResolverComposition)

--- a/platform/galaxy/wrangler.toml
+++ b/platform/galaxy/wrangler.toml
@@ -16,6 +16,9 @@ services = [
 
 unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
+[vars]
+JWKS_INTERNAL_URL_BASE = 'http://127.0.0.1:10001/.well-known/jwks.json'
+
 [dev]
 port = 10401
 inspector_port = 11401
@@ -27,6 +30,8 @@ analytics_engine_datasets = [
 
 unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
+[env.dev.vars]
+JWKS_INTERNAL_URL_BASE = "https://passport-dev.pz3r0.com/.well-known/jwks.json"
 
 [env.dev]
 route = { pattern = "galaxy-dev.rollup.id", custom_domain = true, zone_name = "rollup.id" }
@@ -43,6 +48,9 @@ analytics_engine_datasets = [
 
 unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
+[env.next.vars]
+JWKS_INTERNAL_URL_BASE = "https://passport-next.pz3r0.com/.well-known/jwks.json"
+
 [env.next]
 route = { pattern = "galaxy-next.rollup.id", custom_domain = true, zone_name = "rollup.id" }
 services = [
@@ -57,6 +65,9 @@ analytics_engine_datasets = [
 ]
 
 unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
+
+[env.current.vars]
+JWKS_INTERNAL_URL_BASE = "https://passport.pz3r0.com/.well-known/jwks.json"
 
 [env.current]
 route = { pattern = "galaxy.rollup.id", custom_domain = true, zone_name = "rollup.id" }

--- a/platform/starbase/src/jsonrpc/context.ts
+++ b/platform/starbase/src/jsonrpc/context.ts
@@ -28,6 +28,7 @@ interface CreateInnerContextOptions
   INTERNAL_PASSPORT_SERVICE_NAME: string
   INTERNAL_CLOUDFLARE_ZONE_ID: string
   TOKEN_CLOUDFLARE_API: string
+  JWKS_INTERNAL_URL_BASE: string
 }
 /**
  * Inner context. Will always be available in your procedures, in contrast to the outer context.

--- a/platform/starbase/src/types.ts
+++ b/platform/starbase/src/types.ts
@@ -26,6 +26,7 @@ export interface Environment {
   INTERNAL_PASSPORT_SERVICE_NAME: string
   INTERNAL_CLOUDFLARE_ZONE_ID: string
   TOKEN_CLOUDFLARE_API: string
+  JWKS_INTERNAL_URL_BASE: string
 }
 
 export const EDGE_APPLICATION: EdgeURN = EdgeSpace.urn('owns/app')

--- a/platform/starbase/wrangler.toml
+++ b/platform/starbase/wrangler.toml
@@ -55,6 +55,7 @@ unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 
 [vars]
 ENVIRONMENT = "local"
+JWKS_INTERNAL_URL_BASE = "http://127.0.0.1:10001/.well-known/jwks.json"
 
 # Dev
 # -----------------------------------------------------------------------------
@@ -100,6 +101,8 @@ unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 [env.dev.vars]
 ENVIRONMENT = "dev"
 INTERNAL_PASSPORT_SERVICE_NAME = "passport-dev"
+JWKS_INTERNAL_URL_BASE = "https://passport-dev.pz3r0.com/.well-known/jwks.json"
+
 
 # Environment: next
 # -----------------------------------------------------------------------------
@@ -121,6 +124,7 @@ unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 [env.next.vars]
 ENVIRONMENT = "next"
 INTERNAL_PASSPORT_SERVICE_NAME = "passport-next"
+JWKS_INTERNAL_URL_BASE = "https://passport-next.pz3r0.com/.well-known/jwks.json"
 
 # Environment: current
 # -----------------------------------------------------------------------------
@@ -142,3 +146,4 @@ unsafe.bindings = [{ type = "metadata", name = "ServiceDeploymentMetadata" }]
 [env.current.vars]
 ENVIRONMENT = "current"
 INTERNAL_PASSPORT_SERVICE_NAME = "passport-current"
+JWKS_INTERNAL_URL_BASE = "https://passport.pz3r0.com/.well-known/jwks.json"


### PR DESCRIPTION
### Description

- Implements JWKS-based JWT validation at every worker (with JWKS retrieval being cached with the worker). 
- Implements an enhancement to Galaxy middleware to do resolver-level, optional scope-based security. 

Note: old resolvers that are no longer used by Profile or other features have been removed from being referenced in compositions, but the code remains for later.

### Related Issues

- Closes #1795
- Closes #1507

### Testing

Generated access token based on a crafted authorization request. With it and with an API key, submitted GQL request to Galaxy. 
- With the jwt trailed modified, the request failed JWT validation. 
- With the correct JWT trailer, but with access token not having required scope for GQL request, authorization validation failed.
- Otherwise, request succeeded. 

Also tested main flows through the apps (Passport, Console and Profile) to ensure no regressions.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
