### PR TITLE
fix(passport): Dark mode fix for create smart contract wallet screen

### DIFF
--- a/apps/passport/app/routes/create/wallet.tsx
+++ b/apps/passport/app/routes/create/wallet.tsx
@@ -71,7 +71,8 @@ export default () => {
     <div className={'flex flex-row h-screen justify-center items-center'}>
       <div
         className={
-          'basis-2/5 h-screen w-full hidden lg:flex justify-center items-center bg-indigo-50 overflow-hidden'
+          'basis-2/5 h-screen w-full hidden\
+          lg:flex justify-center items-center bg-indigo-50 overflow-hidden'
         }
       >
         <img src={sideGraphics} alt="Background graphics" />
@@ -82,10 +83,9 @@ export default () => {
             'flex shrink flex-col items-center\
          justify-center gap-4 mx-auto bg-white p-6 h-[100dvh]\
           lg:h-[580px] lg:max-h-[100dvh] w-full lg:w-[418px]\
-          lg:rounded-lg'
+          lg:rounded-lg border dark:bg-gray-800 dark:border-gray-600'
           }
           style={{
-            border: '1px solid #D1D5DB',
             boxSizing: 'border-box',
           }}
         >

--- a/packages/design-system/src/molecules/smart-contract-wallet-connection/SmartContractWalletConnection.tsx
+++ b/packages/design-system/src/molecules/smart-contract-wallet-connection/SmartContractWalletConnection.tsx
@@ -17,7 +17,7 @@ export const SmartContractWalletCreationSummary = ({
 }) => {
   return (
     <div className="flex flex-col items-center w-full h-full">
-      <div className="flex flex-col  items-center w-full h-full space-y-2">
+      <div className="flex flex-col dark:text-white items-center w-full h-full space-y-2">
         <img
           src={scWalletIcon}
           alt="sc_wallet"


### PR DESCRIPTION
### Description

Creates dark mode for SC wallet creation screen in passport

### Related Issues

- Closes #2368

### Testing


<img width="1079" alt="Screenshot 2023-06-07 at 14 07 55" src="https://github.com/proofzero/rollupid/assets/33105890/fb88bf0b-9a20-4a12-b430-b8d062aa5f76">

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
