### PR TITLE
fix(passport): loading transition not shown when logging in with social

### DIFF
--- a/packages/design-system/src/templates/authentication/Authentication.tsx
+++ b/packages/design-system/src/templates/authentication/Authentication.tsx
@@ -196,7 +196,7 @@ const displayKeyMapper = (
           displayContinueWith={displayContinueWith}
           onClick={() => {
             const search = authnQueryParams ? `?${authnQueryParams}` : ''
-            window.location.href = `/connect/${key}${search}`
+            navigate(`/connect/${key}${search}`)
           }}
         />
       )


### PR DESCRIPTION
### Description

Returns Loading component back when loggin-in with non-blockchain oauth providers.

### Related Issues

- Closes #2395

### Testing

Was trying to log in with all providers in passport

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
