### PR TITLE
fix(passport): Connect with Email-Error message on clicking 'Verify' …

### DIFF
--- a/packages/design-system/src/molecules/email-otp-validator/EmailOTPValidator.tsx
+++ b/packages/design-system/src/molecules/email-otp-validator/EmailOTPValidator.tsx
@@ -194,13 +194,14 @@ export default function EmailOTPValidator({
 
                 inputRefs[i].current?.select()
               }}
-              className={`flex text-base lg:text-2xl py-7 px-3.5 h-20 justify-center items-center text-gray-600 dark:text-white dark:bg-gray-800 border rounded-lg text-center ${isInvalid ? 'border-red-500' : 'dark:border-gray-600'
-                }`}
+              className={`flex text-base lg:text-2xl py-7 px-3.5 h-20 justify-center items-center text-gray-600 dark:text-white dark:bg-gray-800 border rounded-lg text-center ${
+                isInvalid ? 'border-red-500' : 'dark:border-gray-600'
+              }`}
             />
           ))}
         </div>
 
-        {showInvalidMessage && invalid && (
+        {!loading && (showInvalidMessage || invalid) && (
           <Text
             size="sm"
             weight="medium"
@@ -217,8 +218,9 @@ export default function EmailOTPValidator({
           <Text
             type="span"
             size="sm"
-            className={`${regenerationRequested ? 'text-gray-300' : 'text-indigo-500'
-              } cursor-pointer relative`}
+            className={`${
+              regenerationRequested ? 'text-gray-300' : 'text-indigo-500'
+            } cursor-pointer relative`}
             onClick={() => {
               if (regenerationRequested) return
 
@@ -258,7 +260,7 @@ export default function EmailOTPValidator({
             btnType="secondary-alt-skin"
             className="flex-1 w-full"
             onClick={onCancel}
-          >Ș
+          >
             Cancel
           </Button>
         )}


### PR DESCRIPTION
…button not displayed for attempts with invalid OTP (post the 1st invalid attempt)

Shows "wrong code" message even on 2nd and 3rd (and even more!) attempt of unsuccessful code enter

[Provide a more detailed description of the change]

### Related Issues

- Closes #2287

### Testing

Directly under `email/verify/` route in passport

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
