### PR TITLE
fix(passport): connected accounts scope is not yellow when user needs to take action 

### DIFF
--- a/packages/design-system/src/templates/authorization/Authorization.tsx
+++ b/packages/design-system/src/templates/authorization/Authorization.tsx
@@ -218,7 +218,7 @@ export default ({
           ${
             scopeMeta.scopes[scope].name === 'Smart contract wallets'
               ? ''
-              : 'text-orange-500'
+              : 'text-orange-500 dark:text-orange-500'
           }
           dark:text-white truncate text-ellipsis
           `}


### PR DESCRIPTION
### Description

Turn connected accounts scope yellow when user needs to take action

### Related Issues

- Closes #2411

### Testing

Locally

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
