### PR TITLE
fix(passport): Refreshing the OTP submission page (with 30 secs interval) generates a new OTP and is shared to related email address

### DIFF
--- a/apps/console/app/routes/apps/$clientId/designer.beta.tsx
+++ b/apps/console/app/routes/apps/$clientId/designer.beta.tsx
@@ -780,6 +780,7 @@ const AuthPanel = ({
                     ]}
                     selectEmailCallback={() => {}}
                     addNewEmailCallback={() => {}}
+                    selectedConnectedAccounts={[]}
                     connectedAccounts={[
                       {
                         title: 'email@example.com',
@@ -814,6 +815,7 @@ const AuthPanel = ({
                           'urn:rollupid:address/0x4416ad52d0d65d4b8852b8041039822e92ff4aa301af1b3ab987bd930f6fb4c8',
                       },
                     ]}
+                    selectedSCWallets={[]}
                     connectedSmartContractWallets={[]}
                     addNewAccountCallback={() => {}}
                     addNewSmartWalletCallback={() => {}}

--- a/apps/passport/app/utils/emailOTP.ts
+++ b/apps/passport/app/utils/emailOTP.ts
@@ -1,0 +1,13 @@
+export const generateEmailOTP = async (
+  email: string
+): Promise<{ message: string; state: string; status: number } | undefined> => {
+  const reqUrl = `/connect/email/otp?email=${encodeURIComponent(email)}`
+
+  const resObj = await fetch(reqUrl)
+  const res = await resObj.json<{
+    message: string
+    state: string
+  }>()
+
+  return { message: res.message, state: res.state, status: resObj.status }
+}

--- a/packages/design-system/src/atoms/buttons/Button.tsx
+++ b/packages/design-system/src/atoms/buttons/Button.tsx
@@ -12,7 +12,7 @@ export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   btnSize?: ButtonSize
   btnType?: ButtonType
   isSubmit?: boolean
-  onClick?: () => unknown
+  onClick?: (e?: any) => unknown
 }
 
 export function Button({

--- a/packages/design-system/src/atoms/info/Info.tsx
+++ b/packages/design-system/src/atoms/info/Info.tsx
@@ -13,10 +13,10 @@ export default function Info({
 }) {
   return (
     <Tooltip
+      arrow={false}
       content={description}
       className="bg-white text-black dark:text-white shadow absolute z-5 w-max"
       placement={placement}
-      
     >
       <img src={iIcon} alt={`${name} info`} />
     </Tooltip>

--- a/packages/design-system/src/templates/authorization/Authorization.tsx
+++ b/packages/design-system/src/templates/authorization/Authorization.tsx
@@ -305,7 +305,6 @@ export default ({
                           {scopeMeta.scopes[scope].description}
                         </p>
                       </div>
-                      <div data-popper-arrow></div>
                     </div>
 
                     <Text

--- a/packages/design-system/src/templates/authorization/Authorization.tsx
+++ b/packages/design-system/src/templates/authorization/Authorization.tsx
@@ -387,7 +387,7 @@ export default ({
           <Text size="sm" className="text-gray-500">
             Before using this app, you can review{' '}
             {appProfile?.name ?? `Company`}
-            `&apos;`s{' '}
+            &apos;s{' '}
             <a href={appProfile.privacyURL} className="text-skin-primary">
               privacy policy
             </a>


### PR DESCRIPTION
### Description

Fix for email OTP screen. Now  not new OTP isn't being sent while refreshing the page on `/email/verify` route. All OTPs are being sent only while clicking buttons and first OTP is being sent while clicking `Send Code` button in `/email` route.

Also introduces minor style fixes in passport

### Related Issues

- Closes #2293

### Testing

Straightforward - go to `authenticate/passport/email` route, enter email and click `Send Code` - see the logs from platform workers.

Then under `verify` route try refreshing and see in logs that it does nothing. Try to issue 5 OTP within 5 minutes and then issue another one

Both pages - `authenticate/passport/email` and `authenticate/passport/email/verify` should show an error

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
