### PR TITLE
fix(passport): displaying app's favicon in custom domain

### DIFF
--- a/apps/passport/app/root.tsx
+++ b/apps/passport/app/root.tsx
@@ -81,10 +81,10 @@ export const links: LinksFunction = () => [
 
 export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
   async ({ request, context, params }) => {
-    let appProps: GetAppPublicPropsResult
+    let appProps
 
     if (context.appProps) {
-      appProps = context.appProps as GetAppPublicPropsResult
+      appProps = context.appProps
     } else {
       appProps = {
         name: `Rollup - ${

--- a/apps/passport/app/root.tsx
+++ b/apps/passport/app/root.tsx
@@ -83,22 +83,26 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
   async ({ request, context, params }) => {
     let appProps: GetAppPublicPropsResult
 
-    if (params?.clientId) {
-      if (params.clientId !== 'console' && params.clientId !== 'passport') {
-        const sbClient = getStarbaseClient('', context.env, context.traceSpan)
-        appProps = await sbClient.getAppPublicProps.query({
-          clientId: params.clientId as string,
-        })
-      } else {
-        appProps = {
-          name: `Rollup - ${
-            params.clientId.charAt(0).toUpperCase() + params.clientId.slice(1)
-          }`,
-          iconURL: LogoIndigo,
-          termsURL: 'https://rollup.id/tos',
-          privacyURL: 'https://rollup.id/privacy-policy',
-          redirectURI: `https://${params.clientId}.rollup.id`,
-          websiteURL: 'https://rollup.id',
+    if (context?.authzQueryParams?.app_props) {
+      appProps = context?.authzQueryParams?.app_props
+    } else {
+      if (params?.clientId) {
+        if (params.clientId !== 'console' && params.clientId !== 'passport') {
+          const sbClient = getStarbaseClient('', context.env, context.traceSpan)
+          appProps = await sbClient.getAppPublicProps.query({
+            clientId: params.clientId as string,
+          })
+        } else {
+          appProps = {
+            name: `Rollup - ${
+              params.clientId.charAt(0).toUpperCase() + params.clientId.slice(1)
+            }`,
+            iconURL: LogoIndigo,
+            termsURL: 'https://rollup.id/tos',
+            privacyURL: 'https://rollup.id/privacy-policy',
+            redirectURI: `https://${params.clientId}.rollup.id`,
+            websiteURL: 'https://rollup.id',
+          }
         }
       }
     }

--- a/apps/passport/app/root.tsx
+++ b/apps/passport/app/root.tsx
@@ -83,27 +83,18 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
   async ({ request, context, params }) => {
     let appProps: GetAppPublicPropsResult
 
-    if (context?.authzQueryParams?.app_props) {
-      appProps = context?.authzQueryParams?.app_props
+    if (context.appProps) {
+      appProps = context.appProps as GetAppPublicPropsResult
     } else {
-      if (params?.clientId) {
-        if (params.clientId !== 'console' && params.clientId !== 'passport') {
-          const sbClient = getStarbaseClient('', context.env, context.traceSpan)
-          appProps = await sbClient.getAppPublicProps.query({
-            clientId: params.clientId as string,
-          })
-        } else {
-          appProps = {
-            name: `Rollup - ${
-              params.clientId.charAt(0).toUpperCase() + params.clientId.slice(1)
-            }`,
-            iconURL: LogoIndigo,
-            termsURL: 'https://rollup.id/tos',
-            privacyURL: 'https://rollup.id/privacy-policy',
-            redirectURI: `https://${params.clientId}.rollup.id`,
-            websiteURL: 'https://rollup.id',
-          }
-        }
+      appProps = {
+        name: `Rollup - ${
+          params.clientId.charAt(0).toUpperCase() + params.clientId.slice(1)
+        }`,
+        iconURL: LogoIndigo,
+        termsURL: 'https://rollup.id/tos',
+        privacyURL: 'https://rollup.id/privacy-policy',
+        redirectURI: `https://${params.clientId}.rollup.id`,
+        websiteURL: 'https://rollup.id',
       }
     }
 
@@ -208,7 +199,7 @@ export default function App() {
     <html lang="en">
       <head>
         <Meta />
-
+        // TODO: switch to V2_MetaFunction
         {browserEnv.appProps?.iconURL ? (
           <>
             <link rel="icon" type="image" href={browserEnv.appProps.iconURL} />
@@ -226,7 +217,6 @@ export default function App() {
             <link rel="icon" type="image/png" href={icon16} sizes="16x16" />
           </>
         )}
-
         <Links />
       </head>
       <body>

--- a/apps/passport/app/root.tsx
+++ b/apps/passport/app/root.tsx
@@ -31,6 +31,7 @@ import icon32 from '~/assets/root-favicon-32x32.png'
 import icon16 from '~/assets/root-favicon-16x16.png'
 import faviconSvg from '~/assets/root-favicon.svg'
 import social from '~/assets/passport-social.png'
+import LogoIndigo from '~/assets/PassportLogoIndigo.svg'
 
 import { Loader } from '@proofzero/design-system/src/molecules/loader/Loader'
 import { ErrorPage } from '@proofzero/design-system/src/pages/error/ErrorPage'
@@ -55,6 +56,8 @@ import { NonceContext } from '@proofzero/design-system/src/atoms/contexts/nonce-
 import useTreeshakeHack from '@proofzero/design-system/src/hooks/useTreeshakeHack'
 import { getRollupReqFunctionErrorWrapper } from '@proofzero/utils/errors'
 import { ThemeContext } from '@proofzero/design-system/src/contexts/theme'
+import { getStarbaseClient } from './platform.server'
+import type { GetAppPublicPropsResult } from '@proofzero/platform/starbase/src/jsonrpc/methods/getAppPublicProps'
 
 export const meta: MetaFunction = () => ({
   charset: 'utf-8',
@@ -78,6 +81,25 @@ export const links: LinksFunction = () => [
 
 export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
   async ({ request, context, params }) => {
+    let appProps: GetAppPublicPropsResult
+    if (params.clientId !== 'console' && params.clientId !== 'passport') {
+      const sbClient = getStarbaseClient('', context.env, context.traceSpan)
+      appProps = await sbClient.getAppPublicProps.query({
+        clientId: params.clientId as string,
+      })
+    } else {
+      appProps = {
+        name: `Rollup - ${
+          params.clientId.charAt(0).toUpperCase() + params.clientId.slice(1)
+        }`,
+        iconURL: LogoIndigo,
+        termsURL: 'https://rollup.id/tos',
+        privacyURL: 'https://rollup.id/privacy-policy',
+        redirectURI: `https://${params.clientId}.rollup.id`,
+        websiteURL: 'https://rollup.id',
+      }
+    }
+
     const flashes = []
     const flashSession = await getFlashSession(request, context.env)
     const flashMessageType = flashSession.get(
@@ -92,6 +114,7 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
 
     return json(
       {
+        appProps,
         flashes,
         ENV: {
           PROFILE_APP_URL: context.env.PROFILE_APP_URL,
@@ -160,8 +183,15 @@ export default function App() {
       <head>
         <Meta />
 
-        {browserEnv.appProps ? (
-          <link rel="icon" type="image" href={browserEnv.appProps.iconURL} />
+        {browserEnv.appProps.iconURL ? (
+          <>
+            <link rel="icon" type="image" href={browserEnv.appProps.iconURL} />
+            <link
+              rel="shortcut icon"
+              type="image"
+              href={browserEnv.appProps.iconURL}
+            />
+          </>
         ) : (
           <>
             <link rel="apple-touch-icon" href={appleIcon} sizes="180x180" />
@@ -200,11 +230,16 @@ export default function App() {
         )}
         {transition.state !== 'idle' && <Loader />}
         <Toaster position="top-right" />
-        {ueComplete && <ThemeContext.Provider value={{
-          dark,
-          theme: undefined
-        }}> <Outlet />
-        </ThemeContext.Provider>}
+        {ueComplete && (
+          <ThemeContext.Provider
+            value={{
+              dark,
+              theme: undefined,
+            }}
+          >
+            <Outlet context={{ appProps: browserEnv.appProps }} />
+          </ThemeContext.Provider>
+        )}
         <ScrollRestoration nonce={nonce} />
         <Scripts nonce={nonce} />
         <script

--- a/apps/passport/app/root.tsx
+++ b/apps/passport/app/root.tsx
@@ -82,21 +82,24 @@ export const links: LinksFunction = () => [
 export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
   async ({ request, context, params }) => {
     let appProps: GetAppPublicPropsResult
-    if (params.clientId !== 'console' && params.clientId !== 'passport') {
-      const sbClient = getStarbaseClient('', context.env, context.traceSpan)
-      appProps = await sbClient.getAppPublicProps.query({
-        clientId: params.clientId as string,
-      })
-    } else {
-      appProps = {
-        name: `Rollup - ${
-          params.clientId.charAt(0).toUpperCase() + params.clientId.slice(1)
-        }`,
-        iconURL: LogoIndigo,
-        termsURL: 'https://rollup.id/tos',
-        privacyURL: 'https://rollup.id/privacy-policy',
-        redirectURI: `https://${params.clientId}.rollup.id`,
-        websiteURL: 'https://rollup.id',
+
+    if (params?.clientId) {
+      if (params.clientId !== 'console' && params.clientId !== 'passport') {
+        const sbClient = getStarbaseClient('', context.env, context.traceSpan)
+        appProps = await sbClient.getAppPublicProps.query({
+          clientId: params.clientId as string,
+        })
+      } else {
+        appProps = {
+          name: `Rollup - ${
+            params.clientId.charAt(0).toUpperCase() + params.clientId.slice(1)
+          }`,
+          iconURL: LogoIndigo,
+          termsURL: 'https://rollup.id/tos',
+          privacyURL: 'https://rollup.id/privacy-policy',
+          redirectURI: `https://${params.clientId}.rollup.id`,
+          websiteURL: 'https://rollup.id',
+        }
       }
     }
 
@@ -202,7 +205,7 @@ export default function App() {
       <head>
         <Meta />
 
-        {browserEnv.appProps.iconURL ? (
+        {browserEnv.appProps?.iconURL ? (
           <>
             <link rel="icon" type="image" href={browserEnv.appProps.iconURL} />
             <link

--- a/apps/passport/app/root.tsx
+++ b/apps/passport/app/root.tsx
@@ -169,12 +169,31 @@ export default function App() {
     )
   }, [browserEnv.flashes])
 
+  const loaderColorHandler = (isDark: boolean): string | undefined => {
+    if (browserEnv?.appProps?.appTheme?.color) {
+      return isDark
+        ? browserEnv?.appProps?.appTheme?.color.dark
+        : browserEnv.appProps.appTheme.color.light
+    }
+  }
+
   const [dark, setDark] = useState<boolean>(false)
+  const [loaderColor, setLoaderColor] = useState<string | undefined>(
+    browserEnv?.appProps?.appTheme?.color?.light
+  )
+
   const [ueComplete, setUEComplete] = useState(false)
   useEffect(() => {
     const darkMode = window.matchMedia('(prefers-color-scheme: dark)')
     setDark(darkMode.matches)
+    setLoaderColor(loaderColorHandler(darkMode.matches))
 
+    window
+      .matchMedia('(prefers-color-scheme: dark)')
+      .addEventListener('change', (event) => {
+        setDark(event.matches)
+        setLoaderColor(loaderColorHandler(event.matches))
+      })
     setUEComplete(true)
   }, [])
 
@@ -228,7 +247,7 @@ export default function App() {
             />
           </>
         )}
-        {transition.state !== 'idle' && <Loader />}
+        {transition.state !== 'idle' && <Loader mainColor={loaderColor} />}
         <Toaster position="top-right" />
         {ueComplete && (
           <ThemeContext.Provider

--- a/apps/passport/app/routes/authenticate/$clientId.tsx
+++ b/apps/passport/app/routes/authenticate/$clientId.tsx
@@ -1,13 +1,11 @@
 import { Outlet, useLoaderData, useOutletContext } from '@remix-run/react'
 import { json } from '@remix-run/cloudflare'
-import { getStarbaseClient } from '~/platform.server'
 import { getAuthzCookieParams } from '~/session.server'
 
 import sideGraphics from '~/assets/auth-side-graphics.svg'
-import LogoIndigo from '~/assets/PassportLogoIndigo.svg'
 
 import type { LoaderFunction } from '@remix-run/cloudflare'
-import { GetAppPublicPropsResult } from '@proofzero/platform/starbase/src/jsonrpc/methods/getAppPublicProps'
+import type { GetAppPublicPropsResult } from '@proofzero/platform/starbase/src/jsonrpc/methods/getAppPublicProps'
 import { Helmet } from 'react-helmet'
 import { getRGBColor, getTextColor } from '@proofzero/design-system/src/helpers'
 import { useContext } from 'react'
@@ -17,24 +15,6 @@ import { ThemeContext } from '@proofzero/design-system/src/contexts/theme'
 
 export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
   async ({ request, context, params }) => {
-    let appProps: GetAppPublicPropsResult
-    if (params.clientId !== 'console' && params.clientId !== 'passport') {
-      const sbClient = getStarbaseClient('', context.env, context.traceSpan)
-      appProps = await sbClient.getAppPublicProps.query({
-        clientId: params.clientId as string,
-      })
-    } else {
-      appProps = {
-        name: `Rollup - ${params.clientId.charAt(0).toUpperCase() + params.clientId.slice(1)
-          }`,
-        iconURL: LogoIndigo,
-        termsURL: 'https://rollup.id/tos',
-        privacyURL: 'https://rollup.id/privacy-policy',
-        redirectURI: `https://${params.clientId}.rollup.id`,
-        websiteURL: 'https://rollup.id',
-      }
-    }
-
     const cp = await getAuthzCookieParams(request, context.env)
 
     let rollup_action
@@ -48,18 +28,19 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
 
     return json({
       clientId: params.clientId,
-      appProps,
       rollup_action,
     })
   }
 )
 
 export default () => {
-  const { clientId, appProps, rollup_action } = useLoaderData<{
+  const { clientId, rollup_action } = useLoaderData<{
     clientId: string
-    appProps: GetAppPublicPropsResult
     rollup_action?: string
   }>()
+
+  const { appProps } = useOutletContext<{ appProps: GetAppPublicPropsResult }>()
+  console.log({ appProps })
 
   const { dark } = useContext(ThemeContext)
 
@@ -69,46 +50,45 @@ export default () => {
         <style type="text/css">{`
             :root {
                 ${getRGBColor(
-          dark
-            ? appProps?.appTheme?.color?.dark ??
-            AuthenticationScreenDefaults.color.dark
-            : appProps?.appTheme?.color?.light ??
-            AuthenticationScreenDefaults.color.light,
-          'primary'
-        )}
+                  dark
+                    ? appProps?.appTheme?.color?.dark ??
+                        AuthenticationScreenDefaults.color.dark
+                    : appProps?.appTheme?.color?.light ??
+                        AuthenticationScreenDefaults.color.light,
+                  'primary'
+                )}
                 ${getRGBColor(
-          getTextColor(
-            dark
-              ? appProps?.appTheme?.color?.dark ??
-              AuthenticationScreenDefaults.color.dark
-              : appProps?.appTheme?.color?.light ??
-              AuthenticationScreenDefaults.color.light
-          ),
-          'primary-contrast-text'
-        )}
+                  getTextColor(
+                    dark
+                      ? appProps?.appTheme?.color?.dark ??
+                          AuthenticationScreenDefaults.color.dark
+                      : appProps?.appTheme?.color?.light ??
+                          AuthenticationScreenDefaults.color.light
+                  ),
+                  'primary-contrast-text'
+                )}
              {
          `}</style>
       </Helmet>
 
       <div className={`${dark ? 'dark' : ''}`}>
-        <div className={`flex flex-row h-[100dvh] justify-center items-center bg-[#F9FAFB] dark:bg-gray-900`}>
+        <div
+          className={`flex flex-row h-[100dvh] justify-center items-center bg-[#F9FAFB] dark:bg-gray-900`}
+        >
           <div
             className={
               'basis-2/5 h-[100dvh] w-full hidden lg:flex justify-center items-center bg-indigo-50 dark:bg-[#1F2937] overflow-hidden'
             }
             style={{
-              backgroundImage: `url(${appProps?.appTheme?.graphicURL ?? sideGraphics
-                })`,
+              backgroundImage: `url(${
+                appProps?.appTheme?.graphicURL ?? sideGraphics
+              })`,
               backgroundSize: 'cover',
               backgroundPosition: 'center',
               backgroundRepeat: 'no-repeat',
             }}
           ></div>
-          <div
-            className={
-              'basis-full basis-full lg:basis-3/5'
-            }
-          >
+          <div className={'basis-full basis-full lg:basis-3/5'}>
             <Outlet context={{ clientId, appProps, rollup_action, dark }} />
           </div>
         </div>

--- a/apps/passport/app/routes/authenticate/$clientId.tsx
+++ b/apps/passport/app/routes/authenticate/$clientId.tsx
@@ -40,7 +40,6 @@ export default () => {
   }>()
 
   const { appProps } = useOutletContext<{ appProps: GetAppPublicPropsResult }>()
-  console.log({ appProps })
 
   const { dark } = useContext(ThemeContext)
 

--- a/apps/passport/app/routes/authenticate/$clientId/email/verify.tsx
+++ b/apps/passport/app/routes/authenticate/$clientId/email/verify.tsx
@@ -14,7 +14,6 @@ import {
 import { getAuthzCookieParams, getUserSession } from '~/session.server'
 import { getAddressClient } from '~/platform.server'
 import { authenticateAddress } from '~/utils/authenticate.server'
-import { Loader } from '@proofzero/design-system/src/molecules/loader/Loader'
 import { useEffect, useState } from 'react'
 
 import type { ActionFunction, LoaderFunction } from '@remix-run/cloudflare'
@@ -125,8 +124,6 @@ export default () => {
         boxSizing: 'border-box',
       }}
     >
-      {transition.state !== 'idle' && <Loader />}
-
       <EmailOTPValidator
         loading={transition.state !== 'idle' || fetcher.state !== 'idle'}
         email={email}

--- a/apps/passport/app/routes/authenticate/$clientId/index.tsx
+++ b/apps/passport/app/routes/authenticate/$clientId/index.tsx
@@ -1,5 +1,4 @@
 import { toast, ToastType } from '@proofzero/design-system/src/atoms/toast'
-import { Loader } from '@proofzero/design-system/src/molecules/loader/Loader'
 import {
   Form,
   useLoaderData,
@@ -292,7 +291,6 @@ export default () => {
 
   return (
     <>
-      {transition.state !== 'idle' && <Loader />}
       <Suspense fallback="">
         <LazyAuth autoConnect={true}>
           <InnerComponent

--- a/apps/passport/app/routes/connect/$address/sign.tsx
+++ b/apps/passport/app/routes/connect/$address/sign.tsx
@@ -40,7 +40,13 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
 
     let signTemplate = AuthenticationScreenDefaults.defaultSignMessage
 
-    const { clientId } = await getAuthzCookieParams(request, context.env)
+    let clientId: string = ''
+    try {
+      const res = await getAuthzCookieParams(request, context.env)
+      clientId = res.clientId
+    } catch (ex) {
+      throw redirect('/')
+    }
     if (clientId !== 'console' && clientId !== 'passport') {
       const sbClient = getStarbaseClient('', context.env, context.traceSpan)
       const appProps = await sbClient.getAppPublicProps.query({

--- a/apps/passport/app/routes/connect/$address/sign.tsx
+++ b/apps/passport/app/routes/connect/$address/sign.tsx
@@ -43,6 +43,9 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
     let clientId: string = ''
     try {
       const res = await getAuthzCookieParams(request, context.env)
+      if (res === null) {
+        throw new Error()
+      }
       clientId = res.clientId
     } catch (ex) {
       throw redirect('/')

--- a/apps/passport/app/routes/settings/applications/$clientId/index.tsx
+++ b/apps/passport/app/routes/settings/applications/$clientId/index.tsx
@@ -43,7 +43,7 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
     return {
       clientId,
       scopeValues,
-      scopeMeta
+      scopeMeta,
     }
   }
 )
@@ -66,11 +66,16 @@ export default () => {
     const aggregator = []
 
     for (const scopeValue of scopeValues.scopes) {
-      if (!scopeValues.claimValues[scopeValue].meta.valid) continue
+      if (
+        Object.keys(scopeValues.claimValues).includes(scopeValue) &&
+        !scopeValues.claimValues[scopeValue].meta.valid
+      )
+        continue
       if (scopeValue === 'email') {
         const profile = connectedProfiles.find(
           //There should be only one address urn provided for email
-          (profile) => profile.urn === scopeValues.claimValues[scopeValue].meta.urns[0]
+          (profile) =>
+            profile.urn === scopeValues.claimValues[scopeValue].meta.urns[0]
         )
         aggregator.push({
           claim: 'email',
@@ -92,16 +97,15 @@ export default () => {
             type: profile.type === 'eth' ? 'blockchain' : profile.type,
           })),
         })
-      } else if (scopeValue === "profile") {
+      } else if (scopeValue === 'profile') {
         aggregator.push({
           claim: 'profile',
           account: {
             address: scopeValues.claimValues[scopeValue].claims.name,
-            icon: scopeValues.claimValues[scopeValue].claims.picture
-          }
+            icon: scopeValues.claimValues[scopeValue].claims.picture,
+          },
         })
-      }
-      else if (scopeValue === 'erc_4337') {
+      } else if (scopeValue === 'erc_4337') {
         const profiles = connectedProfiles.filter((profile) =>
           scopeValues.claimValues[scopeValue].meta.urns.includes(profile.urn)
         )

--- a/apps/passport/app/session.server.ts
+++ b/apps/passport/app/session.server.ts
@@ -283,9 +283,7 @@ export async function getAuthzCookieParams(
     })
     .catch((err) => {
       console.log('No authorization cookie params found')
-      throw new InternalServerError({
-        message: 'No authorization cookie params found',
-      })
+      return null
     })
 }
 

--- a/apps/passport/app/session.server.ts
+++ b/apps/passport/app/session.server.ts
@@ -283,7 +283,9 @@ export async function getAuthzCookieParams(
     })
     .catch((err) => {
       console.log('No authorization cookie params found')
-      throw redirect('/')
+      throw new InternalServerError({
+        message: 'No authorization cookie params found',
+      })
     })
 }
 

--- a/apps/passport/bindings.d.ts
+++ b/apps/passport/bindings.d.ts
@@ -59,7 +59,6 @@ declare global {
     login_hint?: string
     rollup_action?: string
     rollup_result?: string
-    app_props?: GetAppPublicPropsResult
   }
 
   //Same-ish structure, different type name for easier identification

--- a/apps/passport/bindings.d.ts
+++ b/apps/passport/bindings.d.ts
@@ -1,4 +1,5 @@
-import { TraceSpan } from '@proofzero/platform-middleware/trace'
+import type { TraceSpan } from '@proofzero/platform-middleware/trace'
+import type { GetAppPublicPropsResult } from '@proofzero/platform/starbase/src/jsonrpc/methods/getAppPublicProps'
 
 export const seviceBindings = true
 
@@ -58,6 +59,7 @@ declare global {
     login_hint?: string
     rollup_action?: string
     rollup_result?: string
+    app_props?: GetAppPublicPropsResult
   }
 
   //Same-ish structure, different type name for easier identification

--- a/apps/passport/server.ts
+++ b/apps/passport/server.ts
@@ -11,9 +11,14 @@ import {
   generateTraceSpan,
 } from '@proofzero/platform-middleware/trace'
 import type { TraceableFetchEvent } from '@proofzero/platform-middleware/trace'
+import type { GetAppPublicPropsResult } from '@proofzero/platform/starbase/src/jsonrpc/methods/getAppPublicProps'
 
 type CfHostMetadata = {
   clientId: string
+}
+
+type CustomDomainRequest = Request & {
+  app_props: GetAppPublicPropsResult
 }
 
 export function parseParams(request: Request) {
@@ -55,7 +60,7 @@ const requestHandler = createRequestHandler({
     const traceSpan = (event as TraceableFetchEvent).traceSpan
     return {
       authzQueryParams,
-      appProps: event.request.app_props,
+      appProps: (event.request as CustomDomainRequest).app_props,
       env,
       traceSpan,
     }

--- a/apps/passport/server.ts
+++ b/apps/passport/server.ts
@@ -11,12 +11,15 @@ import {
   generateTraceSpan,
 } from '@proofzero/platform-middleware/trace'
 import type { TraceableFetchEvent } from '@proofzero/platform-middleware/trace'
+import type { GetAppPublicPropsResult } from '@proofzero/platform/starbase/src/jsonrpc/methods/getAppPublicProps'
 
 type CfHostMetadata = {
   clientId: string
 }
 
-export function parseParams(request: Request) {
+export function parseParams(
+  request: Request & { app_props?: GetAppPublicPropsResult }
+) {
   const url = new URL(request.url)
   const clientId = url.searchParams.get('client_id') || ''
   const state = url.searchParams.get('state') || ''
@@ -27,6 +30,7 @@ export function parseParams(request: Request) {
   const login_hint = url.searchParams.get('login_hint') || undefined
   const rollup_action = url.searchParams.get('rollup_action') || undefined
   const rollup_result = url.searchParams.get('rollup_result') || undefined
+  const app_props = request.app_props || undefined
 
   const decodedScope =
     scope &&
@@ -43,6 +47,7 @@ export function parseParams(request: Request) {
     login_hint,
     rollup_action,
     rollup_result,
+    app_props: app_props,
   }
 }
 
@@ -90,6 +95,7 @@ const handleEvent = async (event: FetchEvent) => {
 
     try {
       const app = await starbaseClient.getAppPublicProps.query({ clientId })
+      newEvent.request.app_props = app
       const { customDomain } = app
       if (!customDomain) return new Response(null, { status: 404 })
       if (!customDomain.isActive || host !== customDomain?.hostname)

--- a/apps/passport/server.ts
+++ b/apps/passport/server.ts
@@ -11,15 +11,12 @@ import {
   generateTraceSpan,
 } from '@proofzero/platform-middleware/trace'
 import type { TraceableFetchEvent } from '@proofzero/platform-middleware/trace'
-import type { GetAppPublicPropsResult } from '@proofzero/platform/starbase/src/jsonrpc/methods/getAppPublicProps'
 
 type CfHostMetadata = {
   clientId: string
 }
 
-export function parseParams(
-  request: Request & { app_props?: GetAppPublicPropsResult }
-) {
+export function parseParams(request: Request) {
   const url = new URL(request.url)
   const clientId = url.searchParams.get('client_id') || ''
   const state = url.searchParams.get('state') || ''
@@ -30,7 +27,6 @@ export function parseParams(
   const login_hint = url.searchParams.get('login_hint') || undefined
   const rollup_action = url.searchParams.get('rollup_action') || undefined
   const rollup_result = url.searchParams.get('rollup_result') || undefined
-  const app_props = request.app_props || undefined
 
   const decodedScope =
     scope &&
@@ -47,7 +43,6 @@ export function parseParams(
     login_hint,
     rollup_action,
     rollup_result,
-    app_props: app_props,
   }
 }
 
@@ -60,6 +55,7 @@ const requestHandler = createRequestHandler({
     const traceSpan = (event as TraceableFetchEvent).traceSpan
     return {
       authzQueryParams,
+      appProps: event.request.app_props,
       env,
       traceSpan,
     }

--- a/packages/design-system/src/molecules/loader/Loader.tsx
+++ b/packages/design-system/src/molecules/loader/Loader.tsx
@@ -2,8 +2,6 @@ import React from 'react'
 import styled, { keyframes } from 'styled-components'
 
 export const Loader = ({ mainColor }: { mainColor?: string }) => {
-  console.log({ mainColor })
-
   const loaderBackgroundAnimation = keyframes`
   0%, 24.9% {
       background-color: #e5e7eb;

--- a/packages/design-system/src/molecules/loader/Loader.tsx
+++ b/packages/design-system/src/molecules/loader/Loader.tsx
@@ -1,7 +1,104 @@
 import React from 'react'
 import styled, { keyframes } from 'styled-components'
 
-export const Loader = () => {
+export const Loader = ({ mainColor }: { mainColor?: string }) => {
+  console.log({ mainColor })
+
+  const loaderBackgroundAnimation = keyframes`
+  0%, 24.9% {
+      background-color: #e5e7eb;
+    }
+    25%, 49.9% {
+      background-color: #d1d5db;
+    }
+    50%, 74.9% {
+      background-color: #9ca3af;
+    }
+    75%, 100% {
+      background-color: ${mainColor ? mainColor : '#6366f1'};
+    }
+  `
+
+  const loaderFrontAnimation = keyframes`
+  0% {
+      width: 0;
+      background-color: #d1d5db;
+    }
+    24.9% {
+      width: 50%;
+      background-color: #d1d5db;
+    }
+    25% {
+      width: 0;
+      background-color: #9ca3af;
+    }
+    49.9% {
+      width: 50%;
+      background-color: #9ca3af;
+    }
+    50% {
+      width: 0;
+      background-color: ${mainColor ? mainColor : '#6366f1'};
+    }
+    74.9% {
+      width: 50%;
+      background-color: ${mainColor ? mainColor : '#6366f1'};
+    }
+    75% {
+      width: 0%;
+      background-color: #e5e7eb;
+    }
+    100% {
+      width: 50%;
+      background-color: #e5e7eb;
+    }
+  `
+  const Header = styled.header.attrs({
+    role: 'progressbar',
+    'aria-busy': 'true',
+  })`
+    position: fixed;
+    top: 0;
+    left: 0;
+    padding-top: 8px;
+    width: 100%;
+    background-color: #e5e7eb;
+    animation-name: ${loaderBackgroundAnimation};
+    animation-duration: 3.5s;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+    &:before {
+      display: block;
+      position: fixed;
+      top: 0;
+      width: 0;
+      height: 8px;
+      background: #afa;
+      animation: preloader-front linear 3.5s infinite;
+      content: '';
+      right: 50%;
+      animation-name: ${loaderFrontAnimation};
+      animation-duration: 3.5s;
+      animation-timing-function: linear;
+      animation-iteration-count: infinite;
+    }
+    &:after {
+      display: block;
+      position: fixed;
+      top: 0;
+      width: 0;
+      height: 8px;
+      background: #afa;
+      animation: preloader-front linear 3.5s infinite;
+      content: '';
+      left: 50%;
+      animation-name: ${loaderFrontAnimation};
+      animation-duration: 3.5s;
+      animation-timing-function: linear;
+      animation-iteration-count: infinite;
+    }
+  `
+
   return (
     <Header
       style={{
@@ -11,99 +108,3 @@ export const Loader = () => {
     />
   )
 }
-
-const loaderBackgroundAnimation = keyframes`
-0%, 24.9% {
-    background-color: #e5e7eb;
-  }
-  25%, 49.9% {
-    background-color: #d1d5db;
-  }
-  50%, 74.9% {
-    background-color: #9ca3af;
-  }
-  75%, 100% {
-    background-color: #6366f1;
-  }
-`
-
-const loaderFrontAnimation = keyframes`
-0% {
-    width: 0;
-    background-color: #d1d5db;
-  }
-  24.9% {
-    width: 50%;
-    background-color: #d1d5db;
-  }
-  25% {
-    width: 0;
-    background-color: #9ca3af;
-  }
-  49.9% {
-    width: 50%;
-    background-color: #9ca3af;
-  }
-  50% {
-    width: 0;
-    background-color: #6366f1;
-  }
-  74.9% {
-    width: 50%;
-    background-color: #6366f1;
-  }
-  75% {
-    width: 0%;
-    background-color: #e5e7eb;
-  }
-  100% {
-    width: 50%;
-    background-color: #e5e7eb;
-  }
-`
-
-const Header = styled.header.attrs({
-  role: 'progressbar',
-  'aria-busy': 'true',
-})`
-  position: fixed;
-  top: 0;
-  left: 0;
-  padding-top: 8px;
-  width: 100%;
-  background-color: #e5e7eb;
-  animation-name: ${loaderBackgroundAnimation};
-  animation-duration: 3.5s;
-  animation-timing-function: linear;
-  animation-iteration-count: infinite;
-  &:before {
-    display: block;
-    position: fixed;
-    top: 0;
-    width: 0;
-    height: 8px;
-    background: #afa;
-    animation: preloader-front linear 3.5s infinite;
-    content: '';
-    right: 50%;
-    animation-name: ${loaderFrontAnimation};
-    animation-duration: 3.5s;
-    animation-timing-function: linear;
-    animation-iteration-count: infinite;
-  }
-  &:after {
-    display: block;
-    position: fixed;
-    top: 0;
-    width: 0;
-    height: 8px;
-    background: #afa;
-    animation: preloader-front linear 3.5s infinite;
-    content: '';
-    left: 50%;
-    animation-name: ${loaderFrontAnimation};
-    animation-duration: 3.5s;
-    animation-timing-function: linear;
-    animation-iteration-count: infinite;
-  }
-`

--- a/packages/platform-middleware/trace.ts
+++ b/packages/platform-middleware/trace.ts
@@ -1,5 +1,4 @@
 import generateRandomString from '@proofzero/packages/utils/generateRandomString'
-import { GetAppPublicPropsResult } from '@proofzero/platform/starbase/src/jsonrpc/methods/getAppPublicProps'
 
 type TraceId = string
 type TraceParentId = string
@@ -8,7 +7,6 @@ export const TRACEPARENT_HEADER_NAME = 'traceparent' as const
 type TRACEPARENT_HEADER_NAME = typeof TRACEPARENT_HEADER_NAME
 export type TraceableFetchEvent = {
   traceSpan: TraceSpan
-  readonly request: Request & { app_props?: GetAppPublicPropsResult }
 } & FetchEvent
 
 export class TraceSpan {

--- a/packages/platform-middleware/trace.ts
+++ b/packages/platform-middleware/trace.ts
@@ -1,4 +1,5 @@
 import generateRandomString from '@proofzero/packages/utils/generateRandomString'
+import { GetAppPublicPropsResult } from '@proofzero/platform/starbase/src/jsonrpc/methods/getAppPublicProps'
 
 type TraceId = string
 type TraceParentId = string
@@ -7,6 +8,7 @@ export const TRACEPARENT_HEADER_NAME = 'traceparent' as const
 type TRACEPARENT_HEADER_NAME = typeof TRACEPARENT_HEADER_NAME
 export type TraceableFetchEvent = {
   traceSpan: TraceSpan
+  readonly request: Request & { app_props?: GetAppPublicPropsResult }
 } & FetchEvent
 
 export class TraceSpan {


### PR DESCRIPTION
### Description

App's favicon on now displayed on the MetaMask Notification window

Loader in passport now reflects colours that were set in designer for specific app

Fixes bugs with redirects in passport which were not indicated in any other issues, stable temporary solution for `/sign` route when there's an error occurs. Solves issue with `/authenticate` route to not redirect to `/settings/dashboard` logged-in users.

Fetches appProps from starbase before loading context and puts it in the context object.

### Related Issues

- Closes #2406
- Closes #2392 

### Testing

Go to authn screen and pop-up metamask window to sign a message. Under custom domain or just with clientId for the specific app.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
