### PR TITLE
chore(platform): Extend worker interfaces for batch operations

### DIFF
--- a/apps/passport/app/routes/settings.tsx
+++ b/apps/passport/app/routes/settings.tsx
@@ -78,13 +78,12 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
       nodeType: a.rc.node_type,
     })) as { urn: AddressURN; nodeType: NodeType }[]
 
-    const addresses = addressTypeUrns.map(atu => atu.urn)
+    const addresses = addressTypeUrns.map((atu) => atu.urn)
     const addressClient = getAddressClient(
       NO_OP_ADDRESS_PLACEHOLDER,
       context.env,
       context.traceSpan
     )
-
 
     const apps = await accountClient.getAuthorizedApps.query({
       account: accountUrn,
@@ -93,43 +92,39 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
     const awaitedResults = await Promise.all([
       Promise.all(
         apps.map(async (a) => {
-          try {
-            const [appPublicProps, appAuthorizedScopes] = await Promise.all([
-              starbaseClient.getAppPublicProps.query({
-                clientId: a.clientId,
-              }),
-              accessClient.getAuthorizedAppScopes.query({
-                clientId: a.clientId,
-                accountURN: accountUrn,
-              }),
-            ])
+          const appAuthorizedScopes =
+            await accessClient.getAuthorizedAppScopes.query({
+              clientId: a.clientId,
+              accountURN: accountUrn,
+            })
 
-            return {
-              clientId: a.clientId,
-              icon: appPublicProps.iconURL,
-              title: appPublicProps.name,
-              timestamp: a.timestamp,
-              appScopeError: Object.entries(appAuthorizedScopes.claimValues).some(
-                ([_, value]) => !value.meta.valid
-              ),
-            }
-          } catch (e) {
-            //We swallow the error and move on to next app
-            console.error(e)
-            return {
-              clientId: a.clientId,
-              icon: noImg,
-              timestamp: a.timestamp,
-              appDataError: true,
-            }
+          return {
+            clientId: a.clientId,
+            timestamp: a.timestamp,
+            appScopeError: Object.entries(
+              appAuthorizedScopes.claimValues
+            ).some(([_, value]) => !value.meta.valid),
           }
         })
       ),
-      addressClient.getAddressProfileBatch.query(addresses)
+      starbaseClient.getAppPublicPropsBatch.query({
+        apps: apps.map((a) => ({ clientId: a.clientId })),
+        silenceErrors: true,
+      }),
+      addressClient.getAddressProfileBatch.query(addresses),
     ])
 
-    const authorizedApps = awaitedResults[0]
-    const addressProfiles = awaitedResults[1]
+    const [authorizedApps, appsPublicProps, addressProfiles] = awaitedResults
+
+    const authzAppResults: AuthorizedAppsModel[] = []
+    authorizedApps.forEach((authzApp, index) => {
+      //Merging props from authorizedApps and appsPublicProps
+      const appPublicProps = appsPublicProps[index]
+      if (appPublicProps)
+        authzAppResults.push({ ...authzApp, icon: appPublicProps.iconURL, title: appPublicProps.name })
+      else
+        authzAppResults.push({ ...authzApp, icon: noImg, appDataError: true })
+    })
 
     const normalizedConnectedProfiles = addressProfiles.map((p, i) => ({
       ...addressTypeUrns[i],
@@ -139,7 +134,7 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
     return json({
       pfpUrl: accountProfile?.pfp?.image,
       displayName: accountProfile?.displayName,
-      authorizedApps: authorizedApps,
+      authorizedApps: authzAppResults,
       connectedProfiles: normalizedConnectedProfiles,
       CONSOLE_URL: context.env.CONSOLE_APP_URL,
       primaryAddressURN: accountProfile?.primaryAddressURN,

--- a/apps/passport/app/routes/settings/applications/$clientId/index.tsx
+++ b/apps/passport/app/routes/settings/applications/$clientId/index.tsx
@@ -66,6 +66,7 @@ export default () => {
     const aggregator = []
 
     for (const scopeValue of scopeValues.scopes) {
+      if (!scopeValues.claimValues[scopeValue].meta.valid) continue
       if (scopeValue === 'email') {
         const profile = connectedProfiles.find(
           //There should be only one address urn provided for email
@@ -112,7 +113,7 @@ export default () => {
             title: profile.title,
             type: 'blockchain',
           })),
-        }) 
+        })
       } else if (scopeMeta[scopeValue].hidden) {
         aggregator.push({
           claim: 'system_identifiers',

--- a/packages/security/persona.ts
+++ b/packages/security/persona.ts
@@ -514,7 +514,8 @@ export async function getClaimValues(
         personaData,
         traceSpan
       )
-      result = { ...result, ...claimData }
+      // result = { ...result, ...claimData }
+      result = { ...result, ...createInvalidClaimDataObject(scopeValue) }
     } catch (e) {
       //In cases of errors in retriever, we don't retrun any claims and we mark the object
       //as invalid. It's the responsibility of caller to handle that upstream.

--- a/packages/security/persona.ts
+++ b/packages/security/persona.ts
@@ -514,8 +514,7 @@ export async function getClaimValues(
         personaData,
         traceSpan
       )
-      // result = { ...result, ...claimData }
-      result = { ...result, ...createInvalidClaimDataObject(scopeValue) }
+      result = { ...result, ...claimData }
     } catch (e) {
       //In cases of errors in retriever, we don't retrun any claims and we mark the object
       //as invalid. It's the responsibility of caller to handle that upstream.

--- a/platform/address/src/constants.ts
+++ b/platform/address/src/constants.ts
@@ -1,3 +1,9 @@
+import {
+  CryptoAddressType,
+  EmailAddressType,
+  NodeType,
+} from '@proofzero/types/address'
+import { AddressURN, AddressURNSpace } from '@proofzero/urns/address'
 import { EdgeSpace, EdgeURN } from '@proofzero/urns/edge'
 
 export const ACCOUNT_OPTIONS = {
@@ -15,3 +21,12 @@ export const EMAIL_VERIFICATION_OPTIONS = {
 }
 
 export const EDGE_ADDRESS: EdgeURN = EdgeSpace.urn('owns/address')
+
+//Needed for address operations where the single addressUrn passed during creation isn't the one
+//being operated on, as method interfaces have more appropriate addressURN structures for operation
+//in question
+export const NO_OP_ADDRESS_PLACEHOLDER = AddressURNSpace.componentizedUrn(
+  'urn:rollupid/address:z-no-op-address-placeholder',
+  { addr_type: EmailAddressType.Email, node_type: NodeType.Email },
+  { alias: 'no-op-address-placeholder' }
+)

--- a/platform/address/src/jsonrpc/router.ts
+++ b/platform/address/src/jsonrpc/router.ts
@@ -19,6 +19,9 @@ import {
   GetAddressAvatarOutput,
 } from './methods/getAddressAvatar'
 import {
+  GetAddressProfileBatchInput,
+  getAddressProfileBatchMethod,
+  GetAddressProfileBatchOutput,
   getAddressProfileMethod,
   GetAddressProfileOutput,
 } from './methods/getAddressProfile'
@@ -151,6 +154,17 @@ export const appRouter = t.router({
     .use(Analytics)
     .output(GetAddressProfileOutput)
     .query(getAddressProfileMethod),
+  getAddressProfileBatch: t.procedure
+    .use(LogUsage)
+    .use(parse3RN)
+    .use(checkCryptoNodes)
+    .use(checkOAuthNode)
+    .use(setAddressNodeClient)
+    .use(initAddressNode)
+    .use(Analytics)
+    .input(GetAddressProfileBatchInput)
+    .output(GetAddressProfileBatchOutput)
+    .query(getAddressProfileBatchMethod),
   setNickname: t.procedure
     .use(LogUsage)
     .use(parse3RN)

--- a/platform/address/src/nodes/contract.ts
+++ b/platform/address/src/nodes/contract.ts
@@ -31,7 +31,7 @@ export default class ContractAddress {
     )) as CryptoAddressProfile
     profile.icon = profile.icon || gradient
 
-    if (profile.title?.startsWith('0x') && nickname) {
+    if (nickname) {
       profile.title = nickname
     }
 
@@ -42,13 +42,8 @@ export default class ContractAddress {
 }
 
 const getCryptoAddressProfile = async (address: string) => {
-  const ensClient = new ENSUtils()
-  const { avatar, displayName } = await ensClient.getEnsEntry(address)
-
   return {
     address: address,
-    title: displayName,
-    icon: avatar,
     type: CryptoAddressType.Wallet,
   }
 }

--- a/platform/edges/src/db/index.ts
+++ b/platform/edges/src/db/index.ts
@@ -50,9 +50,6 @@ export function init(db: D1Database): Graph {
   }
 }
 
-// node()
-// -----------------------------------------------------------------------------
-
 /**
  * Lookup a single node in the database and return it as an object.
  */
@@ -61,6 +58,16 @@ export async function node(
   filter: NodeFilter
 ): Promise<Node | undefined> {
   return select.node(g, filter)
+}
+
+/**
+ * Lookup a multiple node in the database and return them as objects.
+ */
+export async function nodeBatch(
+  g: Graph,
+  filters: NodeFilter[]
+): Promise<(Node | undefined)[]> {
+  return select.nodeBatch(g, filters)
 }
 
 // edges()

--- a/platform/edges/src/db/select.ts
+++ b/platform/edges/src/db/select.ts
@@ -126,13 +126,57 @@ export async function rc(g: GraphDB, nodeId: AnyURN): Promise<RComponents> {
   } else return {}
 }
 
-// node()
-// -----------------------------------------------------------------------------
+export async function nodeBatch(
+  g: GraphDB,
+  filters: NodeFilter[]
+): Promise<(Node | undefined)[]> {
+  const prepStatements = filters.map((f) => getPrepStatementForNodeFilter(g, f))
+  const batchResults = await g.db.batch(prepStatements)
+  const results = batchResults.map((r) => getNodeFromResultSet(r))
+  return results
+}
 
 export async function node(
   g: GraphDB,
   filter: NodeFilter
 ): Promise<Node | undefined> {
+  const prepStatement = getPrepStatementForNodeFilter(g, filter)
+  const resultSet = await prepStatement.all()
+  const node = getNodeFromResultSet(resultSet)
+  return node
+}
+
+function getNodeFromResultSet(resultSet: D1Result): Node | undefined {
+  type resultRec = {
+    urn: AnyURN
+    compType: compType
+    k: string
+    v: string
+  }
+
+  let node: Node | undefined = undefined
+  for (const result of (resultSet.results as resultRec[]) || []) {
+    if (!node) node = { baseUrn: result.urn, qc: {}, rc: {} }
+    if (node.baseUrn !== result.urn)
+      throw new Error('More than one node found for given criteria.')
+
+    if (result.compType === compType.SRCQ) {
+      const compRec = { [result.k]: result.v }
+      Object.assign(node.qc, compRec)
+    }
+    if (result.compType === compType.SRCR) {
+      const compRec = { [result.k]: result.v }
+      Object.assign(node.rc, compRec)
+    }
+  }
+
+  return node
+}
+
+function getPrepStatementForNodeFilter(
+  g: GraphDB,
+  filter: NodeFilter
+): D1PreparedStatement {
   const sqlBase = `
    with normalizer as (
      select n.*, 'SRCQ' as compType, qc.key as k, qc.value as v
@@ -199,37 +243,8 @@ export async function node(
 
   const finalSqlStatement = sqlBase + conditionsStatement + sqlSuffix
 
-  const resultSet = await g.db
-    .prepare(finalSqlStatement)
-    .bind(...prepBindParams)
-    .all()
-
-  type resultRec = {
-    urn: AnyURN
-    compType: compType
-    k: string
-    v: string
-  }
-
-  let node: Node | undefined = undefined
-  for (const result of (resultSet.results as resultRec[]) || []) {
-    if (!node) node = { baseUrn: result.urn, qc: {}, rc: {} }
-    if (node.baseUrn !== result.urn)
-      throw new Error('More than one node found for given criteria.')
-
-    if (result.compType === compType.SRCQ) {
-      const compRec = { [result.k]: result.v }
-      Object.assign(node.qc, compRec)
-    }
-    if (result.compType === compType.SRCR) {
-      const compRec = { [result.k]: result.v }
-      Object.assign(node.rc, compRec)
-    }
-  }
-
-  //Keep this debug until we're satisfied with the results
-  console.debug('RETURNED NODE', JSON.stringify(node))
-  return node
+  const statement = g.db.prepare(finalSqlStatement).bind(...prepBindParams)
+  return statement
 }
 
 // edges()

--- a/platform/edges/src/jsonrpc/methods/findNode.ts
+++ b/platform/edges/src/jsonrpc/methods/findNode.ts
@@ -3,10 +3,13 @@ import { Context } from '../../context'
 import { Node as NodeSchema } from '../validators/node'
 import * as db from '../../db'
 import { Node, NodeFilter } from '../../db/types'
+import { z } from 'zod'
 
 export const FindNodeMethodInput = NodeFilterInput
 
 export const FindNodeMethodOutput = NodeSchema.optional()
+export const FindNodeBatchMethodInput = z.array(NodeFilterInput)
+export const FindNodeBatchMethodOutput = z.array(FindNodeMethodOutput)
 
 export const findNodeMethod = async ({
   input,
@@ -18,4 +21,15 @@ export const findNodeMethod = async ({
   const node = await db.node(ctx.graph, input)
 
   return node
+}
+
+export const findNodeBatchMethod = async ({
+  input,
+  ctx,
+}: {
+  input: NodeFilter[]
+  ctx: Context
+}): Promise<(Node | undefined)[]> => {
+  const nodes = await db.nodeBatch(ctx.graph, input)
+  return nodes
 }

--- a/platform/edges/src/jsonrpc/router.ts
+++ b/platform/edges/src/jsonrpc/router.ts
@@ -6,6 +6,9 @@ import { errorFormatter } from '@proofzero/utils/trpc'
 import { Context } from '../context'
 
 import {
+  findNodeBatchMethod,
+  FindNodeBatchMethodInput,
+  FindNodeBatchMethodOutput,
   findNodeMethod,
   FindNodeMethodInput,
   FindNodeMethodOutput,
@@ -49,6 +52,12 @@ export const appRouter = t.router({
     .input(FindNodeMethodInput)
     .output(FindNodeMethodOutput)
     .query(findNodeMethod),
+  findNodeBatch: t.procedure
+    .use(LogUsage)
+    .use(Analytics)
+    .input(FindNodeBatchMethodInput)
+    .output(FindNodeBatchMethodOutput)
+    .query(findNodeBatchMethod),
   deleteNode: t.procedure
     .use(LogUsage)
     .use(Analytics)

--- a/platform/starbase/src/jsonrpc/router.ts
+++ b/platform/starbase/src/jsonrpc/router.ts
@@ -58,6 +58,9 @@ import { Analytics } from '@proofzero/platform-middleware/analytics'
 import { OwnAppsMiddleware } from './ownAppsMiddleware'
 import {
   getAppPublicProps,
+  getAppPublicPropsBatch,
+  GetAppPublicPropsBatchInput,
+  GetAppPublicPropsBatchOutput,
   GetAppPublicPropsInput,
   GetAppPublicPropsOutput,
 } from './methods/getAppPublicProps'
@@ -224,6 +227,12 @@ export const appRouter = t.router({
     .input(GetAppPublicPropsInput)
     .output(GetAppPublicPropsOutput)
     .query(getAppPublicProps),
+  getAppPublicPropsBatch: t.procedure
+    .use(LogUsage)
+    .use(Analytics)
+    .input(GetAppPublicPropsBatchInput)
+    .output(GetAppPublicPropsBatchOutput)
+    .query(getAppPublicPropsBatch),
   publishApp: t.procedure
     .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)


### PR DESCRIPTION
### Description

Adds batch interfaces and leverages them for specific "hot paths". The following now have batch variants that take an array of the same type as the non-batch variant.
- Address worker's `getAddressProfile()`
- Edge worker's `findNode()`
- Starbase worker's `getAppPublicProps()`

To get around our previous design choice of having an `AddressURN` be needed for the construction of the Address client, this also introduces a no-op placeholder AddressURN that can be used to initalize a client, so that the batch interfaces (with multiple AddressURNs) can be leveraged.

Also removes ENS lookups for smart contract wallets, due to the worker subrequest multiplication for contract addresses.

Note: `getAuthorizedAppScopes()` will get addressed as part of bigger effort under #2013 

### Related Issues

- Closes #2215
- Closes #2366

### Testing

- Authz screen with previous pre-selection for the connectec accounts.
- Passport settings screen for connected accounts
- Application Claims view for connected accounts
- Being able to load the app with 40+ accounts

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [x] I have updated the documentation (if necessary)
