### PR TITLE
fix(passport): authn screen becomes a dead-end when trying to sing-in with wallet when already signed-in

### DIFF
--- a/apps/passport/app/root.tsx
+++ b/apps/passport/app/root.tsx
@@ -78,18 +78,6 @@ export const links: LinksFunction = () => [
 
 export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
   async ({ request, context, params }) => {
-    const url = new URL(request.url)
-    /**
-     * We use the same technique in profile for `$type/$address` route.
-     * This redirect here prevents us from calling this loader multiple times.
-     * In this case it's essential since flashSessions gets wiped out without
-     * displaying toast messages.
-     */
-
-    if (url.pathname === `/`) {
-      return redirect(`/authenticate`)
-    }
-
     const flashes = []
     const flashSession = await getFlashSession(request, context.env)
     const flashMessageType = flashSession.get(

--- a/apps/passport/app/routes/authenticate/$clientId/index.tsx
+++ b/apps/passport/app/routes/authenticate/$clientId/index.tsx
@@ -225,6 +225,7 @@ const InnerComponent = ({
                 message:
                   'Could not fetch nonce for signing authentication message',
               })
+              navigate('/')
             })
           setLoading(false)
         },

--- a/apps/passport/app/routes/settings.tsx
+++ b/apps/passport/app/routes/settings.tsx
@@ -101,9 +101,9 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
           return {
             clientId: a.clientId,
             timestamp: a.timestamp,
-            appScopeError: Object.entries(
-              appAuthorizedScopes.claimValues
-            ).some(([_, value]) => !value.meta.valid),
+            appScopeError: Object.entries(appAuthorizedScopes.claimValues).some(
+              ([_, value]) => !value.meta.valid
+            ),
           }
         })
       ),
@@ -121,7 +121,11 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
       //Merging props from authorizedApps and appsPublicProps
       const appPublicProps = appsPublicProps[index]
       if (appPublicProps)
-        authzAppResults.push({ ...authzApp, icon: appPublicProps.iconURL, title: appPublicProps.name })
+        authzAppResults.push({
+          ...authzApp,
+          icon: appPublicProps.iconURL,
+          title: appPublicProps.name,
+        })
       else
         authzAppResults.push({ ...authzApp, icon: noImg, appDataError: true })
     })
@@ -173,13 +177,14 @@ export default function SettingsLayout() {
             <div className={`flex flex-col w-full`}>
               <Header pfpUrl={pfpUrl} />
               <div
-                className={`${open
-                  ? 'max-lg:opacity-50\
+                className={`${
+                  open
+                    ? 'max-lg:opacity-50\
                     max-lg:overflow-hidden\
                     max-lg:h-[calc(100dvh-80px)]\
                     min-h-[416px]'
-                  : 'h-full'
-                  } px-2 sm:max-md:px-5 md:px-10
+                    : 'h-full'
+                } px-2 sm:max-md:px-5 md:px-10
                 pb-5 md:pb-10 pt-6 bg-white lg:bg-gray-50`}
               >
                 <Outlet

--- a/apps/passport/app/session.server.ts
+++ b/apps/passport/app/session.server.ts
@@ -283,7 +283,7 @@ export async function getAuthzCookieParams(
     })
     .catch((err) => {
       console.log('No authorization cookie params found')
-      return null
+      throw redirect('/')
     })
 }
 


### PR DESCRIPTION
### Description

When there's already a session app will navigate user to the root loader to then redirect them to settings in passport

### Related Issues

- Closes #2422

### Testing

as described in issue

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
