### PR TITLE
fix(passport): logging-in is prevented when already logged-in

### DIFF
--- a/apps/passport/app/routes/connect/$address/sign.tsx
+++ b/apps/passport/app/routes/connect/$address/sign.tsx
@@ -10,7 +10,10 @@ import { getAuthzRedirectURL } from '../../../utils/authenticate.server'
 
 import { parseJwt } from '@proofzero/packages/utils'
 import { BadRequestError } from '@proofzero/errors'
-import { getRollupReqFunctionErrorWrapper } from '@proofzero/utils/errors'
+import {
+  JsonError,
+  getRollupReqFunctionErrorWrapper,
+} from '@proofzero/utils/errors'
 import type { AccountURN } from '@proofzero/urns/account'
 import {
   AuthenticationScreenDefaults,
@@ -43,12 +46,10 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
     let clientId: string = ''
     try {
       const res = await getAuthzCookieParams(request, context.env)
-      if (res === null) {
-        throw new Error()
-      }
       clientId = res.clientId
     } catch (ex) {
-      throw redirect('/')
+      const traceparent = context.traceSpan.getTraceParent()
+      return JsonError(ex, traceparent)
     }
     if (clientId !== 'console' && clientId !== 'passport') {
       const sbClient = getStarbaseClient('', context.env, context.traceSpan)

--- a/apps/passport/app/utils/emailOTP.ts
+++ b/apps/passport/app/utils/emailOTP.ts
@@ -1,13 +1,20 @@
+import { getErrorCause } from '@proofzero/utils/errors'
+
 export const generateEmailOTP = async (
   email: string
 ): Promise<{ message: string; state: string; status: number } | undefined> => {
   const reqUrl = `/connect/email/otp?email=${encodeURIComponent(email)}`
 
-  const resObj = await fetch(reqUrl)
-  const res = await resObj.json<{
+  const res = await fetch(reqUrl)
+
+  const resObj = await res.json<{
     message: string
     state: string
   }>()
 
-  return { message: res.message, state: res.state, status: resObj.status }
+  if (!res.ok) {
+    throw getErrorCause(resObj)
+  }
+
+  return { message: resObj.message, state: resObj.state, status: res.status }
 }


### PR DESCRIPTION
### Description

Prevents logging-in when already logged-in


### Testing

1. Open `authenticate/passport` in 2 different tabs
2. Log in from one
3. Try to log in with wallet or get email OTP from second one

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
