### PR TITLE
fix(passport): set app name with no custom domain

### DIFF
--- a/apps/passport/app/root.tsx
+++ b/apps/passport/app/root.tsx
@@ -86,16 +86,34 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
     if (context.appProps) {
       appProps = context.appProps
     } else {
-      const name = params.clientId
-        ? params.clientId.charAt(0).toUpperCase() + params.clientId.slice(1)
-        : 'Passport'
-      appProps = {
-        name: `Rollup - ${name}`,
-        iconURL: LogoIndigo,
-        termsURL: 'https://rollup.id/tos',
-        privacyURL: 'https://rollup.id/privacy-policy',
-        redirectURI: `https://${params.clientId}.rollup.id`,
-        websiteURL: 'https://rollup.id',
+      if (!params.clientId) {
+        const name = 'Passport'
+        appProps = {
+          name: `Rollup - ${name}`,
+          iconURL: LogoIndigo,
+          termsURL: 'https://rollup.id/tos',
+          privacyURL: 'https://rollup.id/privacy-policy',
+          redirectURI: `https://passport.rollup.id`,
+          websiteURL: 'https://rollup.id',
+        }
+      } else {
+        if (['console', 'passport'].includes(params.clientId!)) {
+          const name =
+            params.clientId.charAt(0).toUpperCase() + params.clientId.slice(1)
+          appProps = {
+            name: `Rollup - ${name}`,
+            iconURL: LogoIndigo,
+            termsURL: 'https://rollup.id/tos',
+            privacyURL: 'https://rollup.id/privacy-policy',
+            redirectURI: `https://${params.clientId}.rollup.id`,
+            websiteURL: 'https://rollup.id',
+          }
+        } else {
+          const sbClient = getStarbaseClient('', context.env, context.traceSpan)
+          appProps = await sbClient.getAppPublicProps.query({
+            clientId: params.clientId!,
+          })
+        }
       }
     }
 


### PR DESCRIPTION
### Description

There're two separate calls to starbase in passport now:

1. For custom domain appProps are being fetched in `server.ts`.
2. For all other apps without custom domain appProps are being fetched/set in `root.tsx` in `Passport`

Please note that call to starbase happens only once - for custom domains in `server.ts`, for all other apps - in `root.tsx`


### Testing

Tested locally on `Passport`, `Console` and `Profile`

Deployed to dev and tested there on these three apps as well.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
