### PR TITLE
fix(posthog): wrap posthog init in try catch

### DIFF
--- a/apps/console/app/root.tsx
+++ b/apps/console/app/root.tsx
@@ -54,6 +54,7 @@ import { type ServicePlanType } from '@proofzero/types/account'
 import { BadRequestError } from '@proofzero/errors'
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
+import { useHydrated } from 'remix-utils'
 
 export const links: LinksFunction = () => {
   return [
@@ -192,14 +193,21 @@ export default function App() {
     }
   }, [location, GATag])
 
-  // https://posthog.com/docs/libraries/react#posthog-provider
-  if (typeof window !== 'undefined') {
-    posthog.init(loaderData.ENV.POSTHOG_API_KEY, {
-      api_host: POSTHOG_PROXY_HOST,
-    })
+  const hydrated = useHydrated()
+  useEffect(() => {
+    // https://posthog.com/docs/libraries/react#posthog-provider
+    if (hydrated) {
+      try {
+        posthog.init(loaderData.ENV.POSTHOG_API_KEY, {
+          api_host: POSTHOG_PROXY_HOST,
+        })
 
-    posthog?.identify(accountURN)
-  }
+        posthog?.identify(accountURN)
+      } catch (ex) {
+        console.error(ex)
+      }
+    }
+  }, [hydrated])
 
   return (
     <html lang="en" className="h-full">

--- a/apps/passport/app/root.tsx
+++ b/apps/passport/app/root.tsx
@@ -61,6 +61,7 @@ import useTreeshakeHack from '@proofzero/design-system/src/hooks/useTreeshakeHac
 import { getRollupReqFunctionErrorWrapper } from '@proofzero/utils/errors'
 import { ThemeContext } from '@proofzero/design-system/src/contexts/theme'
 import { getStarbaseClient } from './platform.server'
+import { useHydrated } from 'remix-utils'
 export const meta: MetaFunction = () => ({
   charset: 'utf-8',
   title: 'Passport - Rollup',
@@ -168,6 +169,8 @@ export default function App() {
   const transition = useTransition()
   const browserEnv = useLoaderData()
 
+  const hydrated = useHydrated()
+
   const GATag = browserEnv.ENV.INTERNAL_GOOGLE_ANALYTICS_TAG
 
   const remixDevPort = browserEnv.ENV.REMIX_DEV_SERVER_WS_PORT
@@ -217,14 +220,19 @@ export default function App() {
     setUEComplete(true)
   }, [])
 
-  // https://posthog.com/docs/libraries/react#posthog-provider
-  if (typeof window !== 'undefined') {
-    posthog.init(browserEnv.ENV.POSTHOG_API_KEY, {
-      api_host: POSTHOG_PROXY_HOST,
-    })
-
-    posthog?.reset()
-  }
+  useEffect(() => {
+    // https://posthog.com/docs/libraries/react#posthog-provider
+    if (hydrated) {
+      try {
+        posthog.init(browserEnv.ENV.POSTHOG_API_KEY, {
+          api_host: POSTHOG_PROXY_HOST,
+        })
+        posthog?.reset()
+      } catch (ex) {
+        console.error(ex)
+      }
+    }
+  }, [hydrated])
 
   return (
     <html lang="en">


### PR DESCRIPTION
### Description

- PostHog fails and crashes the entire passport / console app. Wrapped in try catch until handled.

### Testing

- Deployed to dev
- Completed flow

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
