### PR TITLE
fix(various): Email AddressURN and Team Email

### DIFF
--- a/apps/console/app/routes/apps/$clientId/team.tsx
+++ b/apps/console/app/routes/apps/$clientId/team.tsx
@@ -23,14 +23,16 @@ import {
   getEmailDropdownItems,
 } from '@proofzero/utils/getNormalisedConnectedAccounts'
 
-
 import type { AddressURN } from '@proofzero/urns/address'
 import type { AccountURN } from '@proofzero/urns/account'
 import type { ActionFunction, LoaderFunction } from '@remix-run/cloudflare'
 import type { errorsTeamProps, notificationHandlerType } from '~/types'
 import { BadRequestError } from '@proofzero/errors'
 import { getRollupReqFunctionErrorWrapper } from '@proofzero/utils/errors'
-import { Dropdown, DropdownSelectListItem } from '@proofzero/design-system/src/atoms/dropdown/DropdownSelectList'
+import {
+  Dropdown,
+  DropdownSelectListItem,
+} from '@proofzero/design-system/src/atoms/dropdown/DropdownSelectList'
 
 export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
   async ({ request, context, params }) => {
@@ -132,8 +134,9 @@ export default () => {
 
   const submit = useSubmit()
 
-  let { connectedEmails } = useLoaderData() as { connectedEmails: Array<DropdownSelectListItem> }
-
+  let { connectedEmails } = useLoaderData() as {
+    connectedEmails: Array<DropdownSelectListItem>
+  }
 
   const { PASSPORT_URL, notificationHandler, appContactAddress } =
     useOutletContext<{
@@ -209,12 +212,12 @@ export default () => {
               <Dropdown
                 items={connectedEmails.map((email: DropdownSelectListItem) => {
                   email.value === appContactAddress
-                    ? email.selected = true
-                    : email.selected = false;
+                    ? (email.selected = true)
+                    : (email.selected = false)
                   // Substituting subtitle with icon
                   // on the client side
                   email.subtitle && !email.icon
-                    ? email.icon = getEmailIcon(email.subtitle)
+                    ? (email.icon = getEmailIcon(email.subtitle))
                     : null
                   return {
                     value: email.value,
@@ -223,7 +226,7 @@ export default () => {
                     title: email.title,
                   }
                 })}
-                placeholder='Select an Email Address'
+                placeholder="Select an Email Address"
                 onSelect={(selected) => {
                   // type casting to DropdownSelectListItem instead of array
                   if (!Array.isArray(selected)) {
@@ -245,7 +248,15 @@ export default () => {
                   }
                 }}
                 ConnectButtonCallback={redirectToPassport}
-                ConnectButtonPhrase='Connect New Email Address'
+                ConnectButtonPhrase="Connect New Email Address"
+                defaultItems={connectedEmails
+                  .filter((el) => el.value === appContactAddress)
+                  .map((email: DropdownSelectListItem) => ({
+                    value: email.value,
+                    selected: email.selected,
+                    icon: email.icon,
+                    title: email.title,
+                  }))}
               />
             </>
           )}

--- a/apps/passport/app/routes/connect/email/otp.ts
+++ b/apps/passport/app/routes/connect/email/otp.ts
@@ -20,7 +20,7 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
         throw new BadRequestError({ message: 'No address included in request' })
 
       const addressURN = AddressURNSpace.componentizedUrn(
-        generateHashedIDRef(EmailAddressType.Email, email),
+        generateHashedIDRef(EmailAddressType.Email, email.toLowerCase()),
         { node_type: NodeType.Email, addr_type: EmailAddressType.Email },
         { alias: email, hidden: 'true' }
       )
@@ -100,7 +100,7 @@ export const action: ActionFunction = getRollupReqFunctionErrorWrapper(
       })
 
     const addressURN = AddressURNSpace.componentizedUrn(
-      generateHashedIDRef(EmailAddressType.Email, email),
+      generateHashedIDRef(EmailAddressType.Email, email.toLowerCase()),
       { node_type: NodeType.Email, addr_type: EmailAddressType.Email },
       { alias: email, hidden: 'true' }
     )


### PR DESCRIPTION
### Description

- Added .toLowerCase to e-mail input when authenticating so that we get the same AddressURN regardless of casing
- Added defaultValue to Team Email Dropdown

### Testing

- Went through a login flow and connect account flow
- Looked at team email dropdown

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
