### PR TITLE
fix(console): Screen side image gets downscaled

### DIFF
--- a/apps/console/app/components/IconPicker/index.tsx
+++ b/apps/console/app/components/IconPicker/index.tsx
@@ -19,7 +19,8 @@ function pickIcon(
     height: number
   },
   minWidth?: number,
-  minHeight?: number
+  minHeight?: number,
+  variant: string = 'public'
 ) {
   return (e: any) =>
     new Promise<any>(async (ok) => {
@@ -87,7 +88,7 @@ function pickIcon(
           }).then((res) => res.json())
 
           const variantUrls = cfUploadRes.result.variants.filter((v) =>
-            v.endsWith('PassportAppCover')
+            v.endsWith(variant)
           )
 
           if (variantUrls.length) {
@@ -128,6 +129,7 @@ type IconPickerProps = {
   setIsFormChanged: (val: boolean) => void
   setIsImgUploading: (val: boolean) => void
   imageUploadCallback?: (url: string) => void
+  variant?: string
 }
 
 export default function IconPicker({
@@ -143,6 +145,7 @@ export default function IconPicker({
   setIsFormChanged,
   setIsImgUploading,
   imageUploadCallback = () => {},
+  variant,
 }: IconPickerProps) {
   const [icon, setIcon] = useState<string>('')
   const [iconUrl, setIconUrl] = useState<string>('')
@@ -283,7 +286,8 @@ export default function IconPicker({
                     maxSize,
                     aspectRatio,
                     minWidth,
-                    minHeight
+                    minHeight,
+                    variant
                   )(event)
                   if (Object.keys(errors).length) {
                     setInvalidState(true)

--- a/apps/console/app/components/IconPicker/index.tsx
+++ b/apps/console/app/components/IconPicker/index.tsx
@@ -86,12 +86,12 @@ function pickIcon(
             body: formData,
           }).then((res) => res.json())
 
-          const publicVariantUrls = cfUploadRes.result.variants.filter((v) =>
-            v.endsWith('public')
+          const variantUrls = cfUploadRes.result.variants.filter((v) =>
+            v.endsWith('PassportAppCover')
           )
 
-          if (publicVariantUrls.length) {
-            setIconUrl(publicVariantUrls[0])
+          if (variantUrls.length) {
+            setIconUrl(variantUrls[0])
           }
         }
 

--- a/apps/console/app/routes/apps/$clientId/designer.tsx
+++ b/apps/console/app/routes/apps/$clientId/designer.tsx
@@ -616,6 +616,7 @@ const AuthPanel = ({
                 errorMessage={
                   errors && errors['graphicURL'] ? errors['graphicURL'] : ''
                 }
+                variant="PassportAppCover"
               />
 
               {graphicURL && (


### PR DESCRIPTION
### Description

- Added a new image variant in cloudflare: PassportAppCover
- Hooked variant to designer screen

### Related Issues

- Closes #2525 

### Testing

- Upload test cover from Ondrej (870x1306), doesn't get downscaled, uses new variant
- Uploded app icon, uses old default ('public') variant

### Futurestuff
- Maybe we'll need to step away from this variant model and go towards a model closer to https://developers.cloudflare.com/images/cloudflare-images/transform/flexible-variants/ but that needs to be investigated, what the pros and cons are.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
