### PR TITLE
fix(console): Service plan entitlement assignment during 3DS

### DIFF
--- a/apps/console/app/utils/billing.ts
+++ b/apps/console/app/utils/billing.ts
@@ -13,6 +13,7 @@ import { type Session, type SessionData } from '@remix-run/cloudflare'
 import { commitFlashSession } from '~/utilities/session.server'
 import { type Env } from 'bindings'
 import Stripe from 'stripe'
+import { type ServicePlanType } from '@proofzero/types/account'
 
 export type StripeInvoice = {
   id: string
@@ -134,6 +135,7 @@ export const process3DSecureCard = async ({
   submit,
   subId,
   redirectUrl,
+  updatePlanParams,
 }: {
   STRIPE_PUBLISHABLE_KEY: string
   status: string
@@ -142,6 +144,11 @@ export const process3DSecureCard = async ({
   submit: SubmitFunction
   subId: string
   redirectUrl?: string
+  updatePlanParams?: {
+    clientId?: string
+    quantity?: number
+    plan: ServicePlanType
+  }
 }) => {
   const stripeClient = await loadStripe(STRIPE_PUBLISHABLE_KEY)
   if (status === 'requires_action') {
@@ -160,6 +167,9 @@ export const process3DSecureCard = async ({
       {
         subId,
         redirectUrl: redirectUrl ? redirectUrl : '/billing',
+        updatePlanParams: updatePlanParams
+          ? JSON.stringify(updatePlanParams)
+          : '',
       },
       {
         method: 'post',


### PR DESCRIPTION
### Description

Doesn't assign entitlement and ProPlan to app if payment requires additional action

### Related Issues

- Closes #2555

### Testing

Buy one entitlement on `$clientId/billing` page using 3DS card.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
