### PR TITLE
fix(edges): Remove now-broken validation check

### DIFF
--- a/platform/edges/src/jsonrpc/methods/deleteNode.ts
+++ b/platform/edges/src/jsonrpc/methods/deleteNode.ts
@@ -24,13 +24,5 @@ export const deleteNodeMethod = async ({
   const statement = remove.node(ctx.graph, nodeUrn)
   const deleted = await ctx.graph.db.batch([statement])
 
-  if (
-    deleted.length > 1 ||
-    (deleted.length === 1 && deleted[0].meta && deleted[0].meta.changes > 1)
-  )
-    //This should never happen, but adding just in case
-    throw new InternalServerError({
-      message: 'Node deletion returned more than one result.',
-    })
   return { deleted: deleted[0].meta.changes === 1 }
 }


### PR DESCRIPTION
### Description

Removing check that no longer works as intended, due to CF backend service changes. `result[x].meta.changes` no longer returns number of rows affected.
This builds on top of the previous functional PR to add the missing `await`.

### Related Issues

- Closes #2323
- Closes #2178

### Testing

Setup: Create identities, add accounts.

- Delete identity and recreate to ensure it's brand new
- Delete non-primary connected account and make sure it can be reconnected.
- Change the primary state on an account and try the cases above.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
