### PR TITLE
fix(console): Remove reference edges before removing app node

### DIFF
--- a/platform/starbase/src/jsonrpc/methods/deleteApp.ts
+++ b/platform/starbase/src/jsonrpc/methods/deleteApp.ts
@@ -41,7 +41,7 @@ export const deleteApp = async ({
     query: { src: { baseUrn: appURN }, tag: EDGE_HAS_REFERENCE_TO },
   })
 
-  const edgesToRemove = [
+  const edgeRemovalPromises = [
     //Reference edges
     ...referenceEdges.edges.map((e) =>
       caller.edges.removeEdge({
@@ -57,7 +57,7 @@ export const deleteApp = async ({
       tag: EDGE_APPLICATION,
     }),
   ]
-  await Promise.all(edgesToRemove)
+  await Promise.all(edgeRemovalPromises)
 
   await caller.edges.deleteNode({
     urn: appURN,


### PR DESCRIPTION
### Description

`deleteApp()` was removing the app edge, but was not also removing the edge references that are used to associate the dev email to the app. This fixes the scenario.

### Related Issues

- Closes #2480

### Testing

1. Create app in Console
2. Associate a dev email in Team and Contacts
3. Go back to dashboard and delete app. 

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
