### PR TITLE
fix(console): Remove certs when subscription fails and entitlement is removed

### DIFF
--- a/platform/starbase/src/jsonrpc/methods/deleteSubscriptionPlans.ts
+++ b/platform/starbase/src/jsonrpc/methods/deleteSubscriptionPlans.ts
@@ -49,6 +49,10 @@ export const deleteSubscriptionPlans = async ({
       // This is a way to delete all app plans
       Promise.all(
         clientIds.map(async (clientId) => {
+          await caller.starbase.deleteCustomDomain({
+            clientId,
+          })
+
           const appDO = await getApplicationNodeByClientId(
             clientId,
             ctx.StarbaseApp


### PR DESCRIPTION
### Description

- Added custom domain removal step in `deleteSubscriptionPlans` method

### Related Issues

- Closes #2583 

### Testing

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [ ] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
