### PR TITLE
fix(Console): Typeform loading blocked

### DIFF
--- a/apps/console/app/entry.server.tsx
+++ b/apps/console/app/entry.server.tsx
@@ -60,6 +60,7 @@ export default function handleRequest(
             SELF,
             'https://js.stripe.com',
             'https://hooks.stripe.com',
+            'form.typeform.com',
           ],
           'script-src': [SELF, `'nonce-${nonce}' ${STRICT_DYNAMIC}`],
           'style-src': [


### PR DESCRIPTION
### Description

Introduced a more specific entry for the iFrame src for typeform

### Related Issues

- Closes #2587 

### Testing

- Works on my machine

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
