### PR TITLE
fix(core): Fix multi-node query method and rare billing email assignment.

### DIFF
--- a/platform/address/src/jsonrpc/methods/getAddressURNForEmail.ts
+++ b/platform/address/src/jsonrpc/methods/getAddressURNForEmail.ts
@@ -26,19 +26,24 @@ export const getAddressURNForEmailMethod = async ({
 }): Promise<GetAddressURNForEmailResult> => {
   const caller = router.createCaller(ctx)
 
-  let node = await caller.edges.findNode({
-    qc: {
-      alias: input,
+  let node = await caller.edges.findNodeBatch([
+    {
+      qc: {
+        alias: input,
+      },
     },
-  })
+  ])
 
   if (!node) {
-    node = await caller.edges.findNode({
-      qc: {
-        alias: input.toLowerCase(),
+    node = await caller.edges.findNodeBatch([
+      {
+        qc: {
+          alias: input.toLowerCase(),
+        },
       },
-    })
+    ])
   }
 
-  return node?.baseUrn as AddressURN
+  //We return first urn
+  return node.length > 0 ? (node[0]?.baseUrn as AddressURN) : undefined
 }


### PR DESCRIPTION
### Description

Corrects condition in rare billing email assignment scenario where a lookup of an urn by email address was returning (validly) multiple nodes, and we were treating that as an error.

### Related Issues

- N/A

### Testing

- Reproduced the issue before deploy and was unable to reproduce after deploy.
- Quick regression test for authorization details - focusing on connected accounts that use some of the same inner method as the ones that had to be tweaked as part of the fix.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
