### PR TITLE
fix(passport): Root loader error check refinement

### DIFF
--- a/apps/passport/app/root.tsx
+++ b/apps/passport/app/root.tsx
@@ -102,15 +102,20 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
           websiteURL: 'https://rollup.id',
         }
       } else {
-        if (['console', 'passport'].includes(params.clientId!)) {
+        if (
+          ['console', 'passport'].includes(params.clientId!) ||
+          (clientId && ['console', 'passport'].includes(clientId))
+        ) {
+          const effectiveClientId = params.clientId! ?? clientId
           const name =
-            params.clientId!.charAt(0).toUpperCase() + params.clientId!.slice(1)
+            effectiveClientId.charAt(0).toUpperCase() +
+            effectiveClientId.slice(1)
           appProps = {
             name: `Rollup - ${name}`,
             iconURL: LogoIndigo,
             termsURL: 'https://rollup.id/tos',
             privacyURL: 'https://rollup.id/privacy-policy',
-            redirectURI: `https://${params.clientId}.rollup.id`,
+            redirectURI: `https://${effectiveClientId}.rollup.id`,
             websiteURL: 'https://rollup.id',
           }
         } else {


### PR DESCRIPTION
### Description

Tweaks the checking of the conditions when authorizing internal apps.

### Related Issues

- N/A

### Testing

Log in to passport and notice no more errors saying `Could not return properties for a published application with Client ID: passport` or `console`

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
