### PR TITLE
chore(console): Adds webauthn/passkeys to Designer

### DIFF
--- a/apps/console/app/routes/apps/$clientId/designer.tsx
+++ b/apps/console/app/routes/apps/$clientId/designer.tsx
@@ -31,6 +31,7 @@ import { DocumentationBadge } from '~/components/DocumentationBadge'
 import { Input } from '@proofzero/design-system/src/atoms/form/Input'
 import Authentication, {
   AuthenticationScreenDefaults,
+  getDisplayNameFromProviderString,
 } from '@proofzero/design-system/src/templates/authentication/Authentication'
 
 import { Avatar } from '@proofzero/packages/design-system/src/atoms/profile/avatar/Avatar'
@@ -233,21 +234,16 @@ const ProviderModal = ({
 }: {
   providers: {
     key: string
+    val: string
     enabled: boolean
   }[]
   isOpen: boolean
   onClose: (val: boolean) => void
-  saveCallback: (providers: { key: string; enabled: boolean }[]) => void
+  saveCallback: (
+    providers: { key: string; val: string; enabled: boolean }[]
+  ) => void
 }) => {
-  const [selectedProviders, setSelectedProviders] = useState(() => {
-    return providers.map((p) => {
-      return {
-        key: p.key,
-        val: _.startCase(p.key),
-        enabled: p.enabled,
-      }
-    })
-  })
+  const [selectedProviders, setSelectedProviders] = useState(providers)
 
   return (
     <Modal isOpen={isOpen} handleClose={() => onClose(false)}>
@@ -370,12 +366,14 @@ const AuthPanel = ({
   const [providers, setProviders] = useState<
     {
       key: string
+      val: string
       enabled: boolean
     }[]
   >(
     appTheme?.providers ??
       AuthenticationScreenDefaults.knownKeys.map((k) => ({
         key: k,
+        val: getDisplayNameFromProviderString(k),
         enabled: true,
       }))
   )
@@ -390,6 +388,7 @@ const AuthPanel = ({
     setProviders(
       AuthenticationScreenDefaults.knownKeys.map((k) => ({
         key: k,
+        val: getDisplayNameFromProviderString(k),
         enabled: true,
       }))
     )

--- a/packages/design-system/src/helpers/get-provider-icons.ts
+++ b/packages/design-system/src/helpers/get-provider-icons.ts
@@ -8,6 +8,7 @@ import google from '../atoms/providers/Google'
 import microsoft from '../atoms/providers/Microsoft'
 import twitter from '../assets/social_icons/twitter.svg'
 import wallets from '../assets/social_icons/wallets.png'
+import webauthn from '../atoms/providers/Webauthn'
 
 export default (provider: string) => {
   switch (provider) {
@@ -17,6 +18,8 @@ export default (provider: string) => {
       return discord
     case 'email':
       return email
+    case 'webauthn':
+      return webauthn
     case 'ethereum':
       return ethereum
     case 'facebook':

--- a/packages/design-system/src/templates/authentication/Authentication.tsx
+++ b/packages/design-system/src/templates/authentication/Authentication.tsx
@@ -47,6 +47,15 @@ This will not trigger a blockchain transaction or cost any gas fees.`,
   radius: 'lg',
 }
 
+export const getDisplayNameFromProviderString = (provider: string): string => {
+  switch (provider) {
+    case 'webauthn':
+      return 'Passkeys'
+    default:
+      return provider.charAt(0).toUpperCase() + provider.substring(1).toLowerCase()
+  }
+}
+
 export const appendNonceTemplate = (signMessage: string) =>
   `${signMessage}${signMessage.endsWith('\n') ? '' : '\n'}\n{{nonce}}`
 

--- a/platform/starbase/src/jsonrpc/validators/app.ts
+++ b/platform/starbase/src/jsonrpc/validators/app.ts
@@ -61,6 +61,7 @@ export const AppThemeSchema = z.object({
     .array(
       z.object({
         key: z.string(),
+        val: z.string(),
         enabled: z.boolean(),
       })
     )


### PR DESCRIPTION
### Description

Adds passkeys to Designer.

### Related Issues

- Closes #2665

### Testing

In designer: 
- Authentication screen preview has passkeys as an option, rendered correctly for light and dark mode
- In Login Provider Configuration, Passkeys is an option that can be reordered and enabled/disabled. 

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
