### PR TITLE
fix(apps): missing `allAppURNs` property in the context

### DIFF
--- a/platform/starbase/src/jsonrpc/ownAppsMiddleware.ts
+++ b/platform/starbase/src/jsonrpc/ownAppsMiddleware.ts
@@ -28,6 +28,7 @@ export const OwnAppsMiddleware: BaseMiddlewareFunction<Context> = async ({
         ctx: {
           ...ctx,
           ownAppURNs,
+          allAppURNs: ownAppURNs,
         },
       })
     }
@@ -44,6 +45,7 @@ export const OwnAppsMiddleware: BaseMiddlewareFunction<Context> = async ({
       ctx: {
         ...ctx,
         ownAppURNs,
+        allAppURNs: ownAppURNs,
       },
     })
   }


### PR DESCRIPTION
### Description

The `allAppURNs` referenced by the methods was not present in two of
the code flow branches.

### Testing

- [x] Manual

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [x] I have updated the documentation (if necessary)