### PR TITLE
fix(passport): "Continue with email" submission button below fold on mobile

### DIFF
--- a/apps/passport/app/components/email/EmailPanel.tsx
+++ b/apps/passport/app/components/email/EmailPanel.tsx
@@ -47,7 +47,7 @@ export const EmailPanel = ({
           Your Email Address
         </Text>
       </section>
-      <section className="flex-1">
+      <section className="mb-4">
         <Input
           type="email"
           id="email"

--- a/apps/passport/app/routes/authenticate/$clientId/email/index.tsx
+++ b/apps/passport/app/routes/authenticate/$clientId/email/index.tsx
@@ -82,7 +82,7 @@ export default () => {
             Your Email Address
           </Text>
         </section>
-        <section className="flex-1">
+        <section className="mb-4">
           <Input
             type="email"
             id="email"
@@ -96,7 +96,7 @@ export default () => {
             <Text
               size="sm"
               weight="medium"
-              className="text-red-500 mt-4 mb-2 text-center"
+              className="text-red-500 mt-4 text-center"
             >
               {errorMessage}
             </Text>

--- a/apps/passport/app/routes/authenticate/$clientId/email/verify.tsx
+++ b/apps/passport/app/routes/authenticate/$clientId/email/verify.tsx
@@ -168,9 +168,10 @@ export default () => {
   return (
     <div
       className={
-        'flex shrink flex-col items-center justify-center gap-4 mx-auto\
-      bg-white p-6 h-[100dvh] lg:h-[580px] lg:max-h-[100dvh] w-full\
-       lg:w-[418px] lg:border-rounded-lg dark:bg-gray-800 border border-[#D1D5DB] dark:border-gray-600'
+        'flex shrink flex-col items-center\
+        gap-4 mx-auto bg-white p-6 h-[100dvh]\
+        lg:h-[580px] lg:max-h-[100dvh] w-full lg:w-[418px]\
+        lg:rounded-lg dark:bg-gray-800 border border-[#D1D5DB] dark:border-gray-600'
       }
       style={{
         boxSizing: 'border-box',

--- a/packages/design-system/src/molecules/email-otp-validator/EmailOTPValidator.tsx
+++ b/packages/design-system/src/molecules/email-otp-validator/EmailOTPValidator.tsx
@@ -120,12 +120,12 @@ export default function EmailOTPValidator({
         </Text>
       </section>
 
-      <section className="flex-1">
+      <section>
         <div className="flex flex-col items-center mt-4 mb-8 text-center">
           <Text className="text-gray-500 dark:text-gray-400">
             We&apos;ve sent a code to
           </Text>
-          <Text className="text-gray-500 dark:text-gray-400 font-medium w-[368px] inline-block float-left whitespace-nowrap truncate">
+          <Text className="text-gray-500 dark:text-gray-400 font-medium max-w-[85dvw] inline-block float-left whitespace-nowrap truncate">
             {email}
           </Text>
         </div>


### PR DESCRIPTION
### Description

- Removed flexor element
- Updated layout to be a simple flex col
- Fixed email overflow bug

### Related Issues

- Closes #2704 
- There are still zooming in issues, unrelated to this bug / fix, when moving from one screen to another. This requires additional investigation and perhaps costly fixes. 

### Testing

Deployed to dev and did the flow with my phone. 

![image](https://github.com/proofzero/rollupid/assets/635806/f68ac4eb-2ff0-4e4a-8abe-e15c2864480c)
![image](https://github.com/proofzero/rollupid/assets/635806/b49fd14d-3e05-42c3-b04c-8697726fed95)
![image](https://github.com/proofzero/rollupid/assets/635806/9d290e4d-3dc8-4637-9277-621815f7e93b)
![image](https://github.com/proofzero/rollupid/assets/635806/6bef327e-a36a-44a1-be87-318584cd6dbd)

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)