### PR TITLE
fix(console): Designer provider list buttons not visible by default

### DIFF
--- a/apps/console/app/routes/apps/$clientId/designer.tsx
+++ b/apps/console/app/routes/apps/$clientId/designer.tsx
@@ -247,10 +247,7 @@ const ProviderModal = ({
 
   return (
     <Modal isOpen={isOpen} handleClose={() => onClose(false)}>
-      <div
-        className="bg-white rounded-lg p-6 min-w-full lg:w-[543px]
-      lg:m-auto overflow-y-auto"
-      >
+      <div className="bg-white rounded-lg p-6 min-w-full lg:w-[543px] lg:m-auto">
         <div className="flex flex-row items-center justify-between mb-4 w-full">
           <Text weight="semibold" className="text-left text-gray-800">
             Login Provider Configuration
@@ -266,7 +263,7 @@ const ProviderModal = ({
           </div>
         </div>
 
-        <section>
+        <section className="max-h-[65vh] overflow-y-scroll">
           <SortableList
             items={selectedProviders}
             itemRenderer={(item) => (


### PR DESCRIPTION
### Description

- Limited provider list height
- Added scroll to provider list section

### Related Issues

- Closes #2713 

### Testing

<img width="664" alt="image" src="https://github.com/proofzero/rollupid/assets/635806/90434aa4-1906-49ee-94be-9fab4e04047e">
<img width="356" alt="image" src="https://github.com/proofzero/rollupid/assets/635806/6265a1a0-5ed5-4d40-84b4-b90a11ab780d">

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
