### PR TITLE
chore(account): use `Environment` object

### DIFF
--- a/platform/account/src/jsonrpc/methods/generateEmailOTP.ts
+++ b/platform/account/src/jsonrpc/methods/generateEmailOTP.ts
@@ -27,7 +27,7 @@ export const generateEmailOTPMethod = async ({
   ctx: Context
 }): Promise<string> => {
   const { email, themeProps, preview } = input
-  const emailAccountNode = new EmailAccount(ctx.account as AccountNode, ctx)
+  const emailAccountNode = new EmailAccount(ctx.account as AccountNode, ctx.env)
 
   const state = generateRandomString(EMAIL_VERIFICATION_OPTIONS.STATE_LENGTH)
 

--- a/platform/account/src/jsonrpc/methods/getAccountProfile.ts
+++ b/platform/account/src/jsonrpc/methods/getAccountProfile.ts
@@ -103,7 +103,7 @@ async function getProfile(
       case CryptoAccountType.Wallet:
         return new ContractAccount(nodeClient)
       case EmailAccountType.Email:
-        return new EmailAccount(nodeClient, ctx)
+        return new EmailAccount(nodeClient, ctx.env)
       case WebauthnAccountType.WebAuthN:
         return new WebauthnAccount(nodeClient, ctx)
       case OAuthAccountType.Apple:

--- a/platform/account/src/jsonrpc/methods/verifyEmailOTP.ts
+++ b/platform/account/src/jsonrpc/methods/verifyEmailOTP.ts
@@ -20,7 +20,7 @@ export const verifyEmailOTPMethod = async ({
   ctx: Context
 }): Promise<z.infer<typeof VerifyEmailOTPOutput>> => {
   const { code, state } = input
-  const emailAccountNode = new EmailAccount(ctx.account as AccountNode, ctx)
+  const emailAccountNode = new EmailAccount(ctx.account as AccountNode, ctx.env)
   const successfulVerification = await emailAccountNode.verifyCode(code, state)
 
   return successfulVerification

--- a/platform/core/src/context.ts
+++ b/platform/core/src/context.ts
@@ -43,6 +43,8 @@ export type DeploymentMetadata = {
 export interface CreateInnerContextOptions
   extends Environment,
     Partial<FetchCreateContextFnOptions & BaseContext> {
+  env: Environment
+
   authorization?: Authorization
   exchangeCode?: ExchangeCode
 
@@ -102,7 +104,7 @@ export async function createContext(
   env: Environment
 ) {
   const { req } = opts
-  const contextInner = await createContextInner({ ...opts, ...env })
+  const contextInner = await createContextInner({ ...opts, ...env, env })
   return {
     ...contextInner,
     req,


### PR DESCRIPTION
### Description

The `Email` account node can be used out of `tRPC` runtime where
`context` object is not available and not possible to construct. The
node class implementations do not have access to `tRPC` stack,
anyway. This is the first change to replace the `tRPC` context object
interface in node class definitions.

This specific change is a dependency for the development branch of #2415.

### Testing

- [x] Manual

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [x] I have updated the documentation (if necessary)