### PR TITLE
chore(platform): delete old images on upload of new ones

### DIFF
--- a/apps/console/app/components/IconPicker/index.tsx
+++ b/apps/console/app/components/IconPicker/index.tsx
@@ -186,7 +186,7 @@ export default function IconPicker({
 
           <div className="grid place-items-center">
             <label
-              htmlFor={id}
+              htmlFor={`${id}_file`}
               className={`rounded bg-transparent text-sm border
                  py-2 px-4 hover:bg-gray-100
                focus:bg-indigo-400 hover:cursor-pointer
@@ -197,9 +197,10 @@ export default function IconPicker({
               </Text>
               <input
                 type="file"
-                id={id}
-                name={id}
+                id={`${id}_file`}
+                name={`${id}_file`}
                 data-variant={variant}
+                data-name={id}
                 accept="image/png,image/jpeg,image/gif,image/webp"
                 className="sr-only"
                 onChange={async (event) => {

--- a/apps/console/app/components/IconPicker/index.tsx
+++ b/apps/console/app/components/IconPicker/index.tsx
@@ -116,7 +116,7 @@ export default function IconPicker({
   setIsFormChanged,
   setIsImgUploading,
   imageUploadCallback = () => {},
-  variant,
+  variant = 'public',
 }: IconPickerProps) {
   const [iconURL, setIconURL] = useState<string>('')
   const [invalidState, setInvalidState] = useState(invalid)

--- a/apps/console/app/routes/apps/$clientId/auth.tsx
+++ b/apps/console/app/routes/apps/$clientId/auth.tsx
@@ -226,7 +226,7 @@ export const action: ActionFunction = getRollupReqFunctionErrorWrapper(
               headers: generateTraceContextHeaders(context.traceSpan),
             })
 
-            imageClient.delete.mutate(ogAppIcon)
+            await imageClient.delete.mutate(ogAppIcon)
           }
         }
         break

--- a/apps/console/app/routes/apps/$clientId/auth.tsx
+++ b/apps/console/app/routes/apps/$clientId/auth.tsx
@@ -208,7 +208,7 @@ export const action: ActionFunction = getRollupReqFunctionErrorWrapper(
         }
 
         if (Object.keys(errors).length === 0) {
-          const ogAppIcon = appDetails.app?.icon
+          const oauthLogo = appDetails.app?.icon
 
           await Promise.all([
             coreClient.starbase.updateApp.mutate({
@@ -221,12 +221,12 @@ export const action: ActionFunction = getRollupReqFunctionErrorWrapper(
             }),
           ])
 
-          if (ogAppIcon && ogAppIcon !== updates.icon) {
+          if (oauthLogo && oauthLogo !== updates.icon) {
             const imageClient = createImageClient(context.env.Images, {
               headers: generateTraceContextHeaders(context.traceSpan),
             })
 
-            await imageClient.delete.mutate(ogAppIcon)
+            await imageClient.delete.mutate(oauthLogo)
           }
         }
         break

--- a/apps/console/app/routes/apps/$clientId/auth.tsx
+++ b/apps/console/app/routes/apps/$clientId/auth.tsx
@@ -11,6 +11,8 @@ import {
   useSubmit,
   useOutletContext,
   useLoaderData,
+  FormMethod,
+  FormEncType,
 } from '@remix-run/react'
 import createCoreClient from '@proofzero/platform-clients/core'
 import { requireJWT } from '~/utilities/session.server'
@@ -337,82 +339,25 @@ export default function AppDetailIndexPage() {
         onSubmitCapture={async (event) => {
           event.preventDefault()
 
-          const getFilteredFileInputs = (formElement: HTMLFormElement) => {
-            return Array.from(
-              formElement.querySelectorAll('input[type="file"]')
-            )
-              .map((input) => input as HTMLInputElement)
-              .filter(
-                (input) =>
-                  input.dataset.variant && input.files && input.files[0]
-              )
-              .map((input) => ({
-                variant: input.dataset.variant,
-                file: input.files![0],
-              }))
-          }
+          const form = event.currentTarget
+          const action = form.action
+          const method = form.method.toLowerCase()
+          const encType = form.enctype.toLowerCase()
 
-          const getUploadUrl = async () => {
-            const response = await fetch('/api/image-upload-url', {
-              method: 'POST',
-            })
-            if (!response.ok) {
-              throw new Error('Failed to retrieve the image upload URL.')
-            }
-            return response.json<string>()
-          }
+          const formData = new FormData(form)
 
-          const uploadFile = async (file: File, uploadUrl: string) => {
-            const formData = new FormData()
-            formData.append('file', file)
-            const response = await fetch(uploadUrl, {
-              method: 'POST',
-              body: formData,
-            })
-            if (!response.ok) {
-              throw new Error('Failed to upload the image.')
-            }
-            return response.json<{
-              result: {
-                variants: string[]
-              }
-            }>()
-          }
+          setIsImgUploading(true)
+          const imgUrls = await cfImgHelper(event)
+          imgUrls.forEach((imgUrl) => {
+            formData.set(imgUrl.name, imgUrl.url)
+          })
+          setIsImgUploading(false)
 
-          const extractVariantUrl = (
-            uploadResponse: {
-              result: {
-                variants: string[]
-              }
-            },
-            variant: string
-          ) => {
-            const variantUrl = uploadResponse.result.variants.find((v) =>
-              v.endsWith(variant)
-            )
-            if (!variantUrl) {
-              throw new Error(`No URL found for variant: ${variant}`)
-            }
-            return variantUrl
-          }
-
-          const formElement = event.currentTarget
-          const filteredFileInputs = getFilteredFileInputs(formElement)
-
-          try {
-            const imgUploadUrl = await getUploadUrl()
-            const fileUrls = await Promise.all(
-              filteredFileInputs.map(async ({ file, variant }) => {
-                const uploadResponse = await uploadFile(file, imgUploadUrl)
-                return extractVariantUrl(uploadResponse, variant!)
-              })
-            )
-
-            console.log(fileUrls)
-            // submit(formElement);
-          } catch (error) {
-            console.error('Error during file upload:', error)
-          }
+          submit(formData, {
+            action,
+            method: method as FormMethod,
+            encType: encType as FormEncType,
+          })
         }}
       >
         <fieldset disabled={isImgUploading}>
@@ -431,7 +376,7 @@ export default function AppDetailIndexPage() {
               <Button
                 type="submit"
                 btnType="primary-alt"
-                disabled={!isFormChanged}
+                disabled={!isFormChanged || isImgUploading}
               >
                 Save
               </Button>
@@ -788,4 +733,83 @@ export default function AppDetailIndexPage() {
       </Form>
     </>
   )
+}
+
+const cfImgHelper = async (event: React.FormEvent<HTMLFormElement>) => {
+  const getFilteredFileInputs = (formElement: HTMLFormElement) => {
+    return Array.from(formElement.querySelectorAll('input[type="file"]'))
+      .map((input) => input as HTMLInputElement)
+      .filter(
+        (input) =>
+          input.dataset.name &&
+          input.dataset.variant &&
+          input.files &&
+          input.files[0]
+      )
+      .map((input) => ({
+        name: input.dataset.name!,
+        variant: input.dataset.variant!,
+        file: input.files![0],
+      }))
+  }
+
+  const getUploadUrl = async () => {
+    const response = await fetch('/api/image-upload-url', {
+      method: 'POST',
+    })
+    if (!response.ok) {
+      throw new Error('Failed to retrieve the image upload URL.')
+    }
+    return response.json<string>()
+  }
+
+  const uploadFile = async (file: File, uploadUrl: string) => {
+    const formData = new FormData()
+    formData.append('file', file)
+    const response = await fetch(uploadUrl, {
+      method: 'POST',
+      body: formData,
+    })
+    if (!response.ok) {
+      throw new Error('Failed to upload the image.')
+    }
+    return response.json<{
+      result: {
+        variants: string[]
+      }
+    }>()
+  }
+
+  const extractVariantUrl = (
+    uploadResponse: {
+      result: {
+        variants: string[]
+      }
+    },
+    variant: string
+  ) => {
+    const variantUrl = uploadResponse.result.variants.find((v) =>
+      v.endsWith(variant)
+    )
+    if (!variantUrl) {
+      throw new Error(`No URL found for variant: ${variant}`)
+    }
+    return variantUrl
+  }
+
+  const formElement = event.currentTarget
+  const filteredFileInputs = getFilteredFileInputs(formElement)
+
+  const imgUploadUrl = await getUploadUrl()
+  const fileUrls = await Promise.all(
+    filteredFileInputs.map(async ({ file, variant, name }) => {
+      const uploadResponse = await uploadFile(file, imgUploadUrl)
+      return {
+        name,
+        url: extractVariantUrl(uploadResponse, variant!),
+      }
+    })
+  )
+
+  return fileUrls
 }

--- a/apps/console/app/routes/apps/$clientId/designer.tsx
+++ b/apps/console/app/routes/apps/$clientId/designer.tsx
@@ -97,6 +97,7 @@ import designerSVG from '~/assets/early/designer.webp'
 import EarlyAccessPanel from '~/components/EarlyAccess/EarlyAccessPanel'
 import { IdentityURN } from '@proofzero/urns/identity'
 import { GetOgThemeResult } from '@proofzero/platform.starbase/src/jsonrpc/methods/getOgTheme'
+import createImageClient from '@proofzero/platform-clients/image'
 
 const LazyAuth = lazy(() =>
   // @ts-ignore :(
@@ -1567,6 +1568,8 @@ export const action: ActionFunction = getRollupReqFunctionErrorWrapper(
       let colorDark = fd.get('colordark') as string | undefined
       if (!colorDark || colorDark === '') colorDark = undefined
 
+      const ogGraphicURL = theme.graphicURL
+
       let graphicURL = fd.get('image') as string | undefined
       if (!graphicURL || graphicURL === '') graphicURL = undefined
 
@@ -1607,6 +1610,14 @@ export const action: ActionFunction = getRollupReqFunctionErrorWrapper(
           clientId,
           theme,
         })
+
+        if (ogGraphicURL && ogGraphicURL !== theme.graphicURL) {
+          const imageClient = createImageClient(context.env.Images, {
+            headers: generateTraceContextHeaders(context.traceSpan),
+          })
+
+          await imageClient.delete.mutate(ogGraphicURL)
+        }
       }
 
       return json({

--- a/apps/console/app/routes/apps/$clientId/designer.tsx
+++ b/apps/console/app/routes/apps/$clientId/designer.tsx
@@ -1573,7 +1573,7 @@ export const action: ActionFunction = getRollupReqFunctionErrorWrapper(
       let colorDark = fd.get('colordark') as string | undefined
       if (!colorDark || colorDark === '') colorDark = undefined
 
-      const ogGraphicURL = theme.graphicURL
+      const ogGraphicURL = theme?.graphicURL
 
       let graphicURL = fd.get('image') as string | undefined
       if (!graphicURL || graphicURL === '') graphicURL = undefined
@@ -1616,7 +1616,7 @@ export const action: ActionFunction = getRollupReqFunctionErrorWrapper(
           theme,
         })
 
-        deleteUpdatedImage(context, ogGraphicURL, graphicURL)
+        await deleteUpdatedImage(context, ogGraphicURL, graphicURL)
       }
 
       return json({
@@ -1625,7 +1625,7 @@ export const action: ActionFunction = getRollupReqFunctionErrorWrapper(
     }
 
     const updateEmail = async (fd: FormData, theme: EmailOTPTheme) => {
-      const ogLogoURL = theme.logoURL
+      const ogLogoURL = theme?.logoURL
       let logoURL = fd.get('logoURL') as string | undefined
       if (!logoURL || logoURL === '') logoURL = undefined
 
@@ -1659,7 +1659,7 @@ export const action: ActionFunction = getRollupReqFunctionErrorWrapper(
           theme,
         })
 
-        deleteUpdatedImage(context, ogLogoURL, logoURL)
+        await deleteUpdatedImage(context, ogLogoURL, logoURL)
       }
 
       return json({
@@ -1674,7 +1674,7 @@ export const action: ActionFunction = getRollupReqFunctionErrorWrapper(
       let description = fd.get('ogDescription') as string | undefined
       if (!description || description === '') description = undefined
 
-      const ogImageURL = theme.image
+      const ogImageURL = theme?.image
       let image = fd.get('ogImage') as string | undefined
       if (!image || image === '') image = undefined
 
@@ -1702,7 +1702,7 @@ export const action: ActionFunction = getRollupReqFunctionErrorWrapper(
           theme,
         })
 
-        deleteUpdatedImage(context, ogImageURL, image)
+        await deleteUpdatedImage(context, ogImageURL, image)
       }
 
       return json({

--- a/apps/console/app/routes/apps/$clientId/designer.tsx
+++ b/apps/console/app/routes/apps/$clientId/designer.tsx
@@ -7,6 +7,7 @@ import {
   useFetcher,
   useLoaderData,
   useOutletContext,
+  useSubmit,
 } from '@remix-run/react'
 import {
   ReactNode,
@@ -103,6 +104,7 @@ import EarlyAccessPanel from '~/components/EarlyAccess/EarlyAccessPanel'
 import { IdentityURN } from '@proofzero/urns/identity'
 import { GetOgThemeResult } from '@proofzero/platform.starbase/src/jsonrpc/methods/getOgTheme'
 import createImageClient from '@proofzero/platform-clients/image'
+import { captureFormSubmitAndReplaceImages } from '~/utils/formCFImages.client'
 
 const LazyAuth = lazy(() =>
   // @ts-ignore :(
@@ -1786,11 +1788,18 @@ export default () => {
     )
   }
 
+  const submit = useSubmit()
+
   return (
     <Suspense fallback={<Loader />}>
       {loading && <Loader />}
 
-      <Form method="post">
+      <Form
+        method="post"
+        onSubmitCapture={(event) =>
+          captureFormSubmitAndReplaceImages(event, submit, setLoading)
+        }
+      >
         <section className="flex flex-col lg:flex-row items-center justify-between mb-11">
           <div className="flex flex-row items-center space-x-3">
             <Text
@@ -1899,6 +1908,6 @@ const deleteUpdatedImage = async (
       headers: generateTraceContextHeaders(context.traceSpan),
     })
 
-    await imageClient.delete.mutate(previousURL)
+    context.waitUntil(imageClient.delete.mutate(previousURL))
   }
 }

--- a/apps/console/app/utils/formCFImages.client.ts
+++ b/apps/console/app/utils/formCFImages.client.ts
@@ -1,0 +1,108 @@
+import { FormEncType, FormMethod, SubmitFunction } from '@remix-run/react'
+
+export const captureFormSubmitAndReplaceImages = async (
+  event: React.FormEvent<HTMLFormElement>,
+  submit: SubmitFunction,
+  imagesUploadCallback: (isUploading: boolean) => void
+) => {
+  event.preventDefault()
+
+  const form = event.currentTarget
+  const action = form.action
+  const method = form.method.toLowerCase()
+  const encType = form.enctype.toLowerCase()
+
+  const formData = new FormData(form)
+
+  imagesUploadCallback(true)
+  const imgUrls = await cfImgHelper(event)
+  imgUrls.forEach((imgUrl) => {
+    formData.set(imgUrl.name, imgUrl.url)
+  })
+  imagesUploadCallback(false)
+
+  submit(formData, {
+    action,
+    method: method as FormMethod,
+    encType: encType as FormEncType,
+  })
+}
+
+const cfImgHelper = async (event: React.FormEvent<HTMLFormElement>) => {
+  const getFilteredFileInputs = (formElement: HTMLFormElement) => {
+    return Array.from(formElement.querySelectorAll('input[type="file"]'))
+      .map((input) => input as HTMLInputElement)
+      .filter(
+        (input) =>
+          input.dataset.name &&
+          input.dataset.variant &&
+          input.files &&
+          input.files[0]
+      )
+      .map((input) => ({
+        name: input.dataset.name!,
+        variant: input.dataset.variant!,
+        file: input.files![0],
+      }))
+  }
+
+  const getUploadUrl = async () => {
+    const response = await fetch('/api/image-upload-url', {
+      method: 'POST',
+    })
+    if (!response.ok) {
+      throw new Error('Failed to retrieve the image upload URL.')
+    }
+    return response.json<string>()
+  }
+
+  const uploadFile = async (file: File, uploadUrl: string) => {
+    const formData = new FormData()
+    formData.append('file', file)
+    const response = await fetch(uploadUrl, {
+      method: 'POST',
+      body: formData,
+    })
+    if (!response.ok) {
+      throw new Error('Failed to upload the image.')
+    }
+    return response.json<{
+      result: {
+        variants: string[]
+      }
+    }>()
+  }
+
+  const extractVariantUrl = (
+    uploadResponse: {
+      result: {
+        variants: string[]
+      }
+    },
+    variant: string
+  ) => {
+    const variantUrl = uploadResponse.result.variants.find((v) =>
+      v.endsWith(variant)
+    )
+    if (!variantUrl) {
+      throw new Error(`No URL found for variant: ${variant}`)
+    }
+    return variantUrl
+  }
+
+  const formElement = event.currentTarget
+  const filteredFileInputs = getFilteredFileInputs(formElement)
+
+  const imgUploadUrl = await getUploadUrl()
+  const fileUrls = await Promise.all(
+    filteredFileInputs.map(async ({ file, variant, name }) => {
+      const uploadResponse = await uploadFile(file, imgUploadUrl)
+      return {
+        name,
+        url: extractVariantUrl(uploadResponse, variant!),
+      }
+    })
+  )
+
+  return fileUrls
+}

--- a/apps/console/server.ts
+++ b/apps/console/server.ts
@@ -18,6 +18,7 @@ declare module '@remix-run/server-runtime' {
   interface AppLoadContext {
     traceSpan: TraceSpan
     env: Env
+    waitUntil: (promise: Promise<any>) => void
   }
 }
 
@@ -48,6 +49,7 @@ const handleEvent = async (event: FetchEvent, env: Env) => {
         return {
           env,
           traceSpan,
+          waitUntil: event.waitUntil,
         }
       },
     })

--- a/apps/profile/app/entry.server.tsx
+++ b/apps/profile/app/entry.server.tsx
@@ -11,6 +11,7 @@ import {
   SELF,
   STRICT_DYNAMIC,
   UNSAFE_INLINE,
+  BLOB,
 } from 'csp-header'
 
 export default function handleRequest(
@@ -45,7 +46,7 @@ export default function handleRequest(
           ],
           'script-src': [SELF, `'nonce-${nonce}' ${STRICT_DYNAMIC}`],
           'style-src': [SELF, UNSAFE_INLINE, 'fonts.cdnfonts.com'],
-          'img-src': [dev ? 'http:' : 'https:', DATA],
+          'img-src': [dev ? 'http:' : 'https:', DATA, BLOB],
           'font-src': [SELF, 'fonts.cdnfonts.com'],
           'object-src': [NONE],
           'base-uri': [SELF],

--- a/apps/profile/app/routes/account/profile.tsx
+++ b/apps/profile/app/routes/account/profile.tsx
@@ -46,6 +46,7 @@ export const action: ActionFunction = async ({ request, context }) => {
     identityURN!,
     'json'
   )
+  const ogImage = currentProfile?.pfp.image
   const updatedProfile = Object.assign(currentProfile || {}, {
     displayName,
     pfp: {
@@ -71,17 +72,12 @@ export const action: ActionFunction = async ({ request, context }) => {
     JSON.stringify(zodValidation.data)
   )
 
-  if (
-    currentProfile &&
-    currentProfile.pfp.image &&
-    !currentProfile.pfp.isToken &&
-    currentProfile.pfp.image !== updatedProfile.pfp.image
-  ) {
+  if (ogImage && ogImage !== updatedProfile.pfp.image) {
     const imageClient = createImageClient(context.env.Images, {
       headers: generateTraceContextHeaders(context.traceSpan),
     })
 
-    await imageClient.delete.mutate(currentProfile.pfp.image)
+    await imageClient.delete.mutate(ogImage)
   }
 
   return null

--- a/apps/profile/app/routes/account/profile.tsx
+++ b/apps/profile/app/routes/account/profile.tsx
@@ -4,6 +4,7 @@ import {
   useOutletContext,
   useTransition,
   useFetcher,
+  useSubmit,
 } from '@remix-run/react'
 import { Button, Text } from '@proofzero/design-system'
 import { FaBriefcase, FaMapMarkerAlt } from 'react-icons/fa'
@@ -26,6 +27,7 @@ import { FullProfileSchema } from '~/validation'
 import InputTextarea from '@proofzero/design-system/src/atoms/form/InputTextarea'
 import createImageClient from '@proofzero/platform-clients/image'
 import { generateTraceContextHeaders } from '@proofzero/platform-middleware/trace'
+import { captureFormSubmitAndReplaceImages } from '~/utils/formCFImages.client'
 
 export const action: ActionFunction = async ({ request, context }) => {
   const { sub: identityURN } = parseJwt(
@@ -77,7 +79,7 @@ export const action: ActionFunction = async ({ request, context }) => {
       headers: generateTraceContextHeaders(context.traceSpan),
     })
 
-    await imageClient.delete.mutate(ogImage)
+    context.waitUntil(imageClient.delete.mutate(ogImage))
   }
 
   return null
@@ -126,46 +128,7 @@ export default function AccountSettingsProfile() {
   const [pfpUploading, setPfpUploading] = useState(false)
   const [isFormChanged, setFormChanged] = useState(false)
 
-  const handlePfpUpload = async (e: any) => {
-    const pfpFile = (e.target as HTMLInputElement & EventTarget).files?.item(0)
-    if (!pfpFile) {
-      return
-    }
-
-    setPfpUploading(true)
-
-    const imgUploadUrl = (await fetch('/account/profile/image-upload-url', {
-      method: 'post',
-    })
-      .then((res) => res.json())
-      .catch((e) => {
-        console.error(e)
-      })) as string
-
-    const formData = new FormData()
-    formData.append('file', pfpFile)
-
-    const cfUploadRes: {
-      success: boolean
-      result: {
-        variants: string[]
-      }
-    } = await fetch(imgUploadUrl, {
-      method: 'POST',
-      body: formData,
-    }).then((res) => res.json())
-
-    const publicVariantUrls = cfUploadRes.result.variants.filter((v) =>
-      v.endsWith('public')
-    )
-
-    if (publicVariantUrls.length) {
-      setPfpUrl(publicVariantUrls[0])
-      setIsToken(false)
-    }
-
-    setPfpUploading(false)
-  }
+  const submit = useSubmit()
 
   // ------------------- START OF MODAL PART ---------------------- //
   // STATE
@@ -234,22 +197,11 @@ export default function AccountSettingsProfile() {
                 Change NFT Avatar
               </Button>
 
-              <input
-                ref={pfpUploadRef}
-                type="file"
-                id="pfp-upload"
-                name="pfp"
-                accept="image/png, image/jpeg"
-                className="sr-only"
-                onChange={handlePfpUpload}
-              />
-
               <Button
                 btnType={'secondary'}
                 btnSize={'sm'}
                 onClick={() => {
                   pfpUploadRef.current?.click()
-                  setFormChanged(true)
                 }}
                 className="!text-gray-600 border-none"
               >
@@ -268,9 +220,28 @@ export default function AccountSettingsProfile() {
           onReset={() => {
             setFormChanged(false)
           }}
+          onSubmitCapture={(event) => {
+            captureFormSubmitAndReplaceImages(event, submit, setPfpUploading)
+          }}
         >
-          <input name="pfp_url" type="hidden" value={pfpUrl} />
           <input name="pfp_isToken" type="hidden" value={isToken ? 1 : 0} />
+          <input
+            ref={pfpUploadRef}
+            type="file"
+            id={`pfp_file`}
+            name={`pfp_file`}
+            data-variant="public"
+            data-name={'pfp_url'}
+            accept="image/png,image/jpeg,image/gif,image/webp"
+            className="sr-only"
+            onChange={(event) => {
+              if (event.target.files?.[0]) {
+                setPfpUrl(URL.createObjectURL(event.target.files?.[0]))
+                setIsToken(false)
+                setFormChanged(true)
+              }
+            }}
+          />
 
           <div className="lg:w-3/6 lg:pr-4">
             <InputText

--- a/apps/profile/app/routes/account/profile.tsx
+++ b/apps/profile/app/routes/account/profile.tsx
@@ -81,7 +81,7 @@ export const action: ActionFunction = async ({ request, context }) => {
       headers: generateTraceContextHeaders(context.traceSpan),
     })
 
-    imageClient.delete.mutate(currentProfile.pfp.image)
+    await imageClient.delete.mutate(currentProfile.pfp.image)
   }
 
   return null

--- a/apps/profile/app/utils/formCFImages.client.ts
+++ b/apps/profile/app/utils/formCFImages.client.ts
@@ -1,0 +1,108 @@
+import { FormEncType, FormMethod, SubmitFunction } from '@remix-run/react'
+
+export const captureFormSubmitAndReplaceImages = async (
+  event: React.FormEvent<HTMLFormElement>,
+  submit: SubmitFunction,
+  imagesUploadCallback: (isUploading: boolean) => void
+) => {
+  event.preventDefault()
+
+  const form = event.currentTarget
+  const action = form.action
+  const method = form.method.toLowerCase()
+  const encType = form.enctype.toLowerCase()
+
+  const formData = new FormData(form)
+
+  imagesUploadCallback(true)
+  const imgUrls = await cfImgHelper(event)
+  imgUrls.forEach((imgUrl) => {
+    formData.set(imgUrl.name, imgUrl.url)
+  })
+  imagesUploadCallback(false)
+
+  submit(formData, {
+    action,
+    method: method as FormMethod,
+    encType: encType as FormEncType,
+  })
+}
+
+const cfImgHelper = async (event: React.FormEvent<HTMLFormElement>) => {
+  const getFilteredFileInputs = (formElement: HTMLFormElement) => {
+    return Array.from(formElement.querySelectorAll('input[type="file"]'))
+      .map((input) => input as HTMLInputElement)
+      .filter(
+        (input) =>
+          input.dataset.name &&
+          input.dataset.variant &&
+          input.files &&
+          input.files[0]
+      )
+      .map((input) => ({
+        name: input.dataset.name!,
+        variant: input.dataset.variant!,
+        file: input.files![0],
+      }))
+  }
+
+  const getUploadUrl = async () => {
+    const response = await fetch('/account/profile/image-upload-url', {
+      method: 'POST',
+    })
+    if (!response.ok) {
+      throw new Error('Failed to retrieve the image upload URL.')
+    }
+    return response.json<string>()
+  }
+
+  const uploadFile = async (file: File, uploadUrl: string) => {
+    const formData = new FormData()
+    formData.append('file', file)
+    const response = await fetch(uploadUrl, {
+      method: 'POST',
+      body: formData,
+    })
+    if (!response.ok) {
+      throw new Error('Failed to upload the image.')
+    }
+    return response.json<{
+      result: {
+        variants: string[]
+      }
+    }>()
+  }
+
+  const extractVariantUrl = (
+    uploadResponse: {
+      result: {
+        variants: string[]
+      }
+    },
+    variant: string
+  ) => {
+    const variantUrl = uploadResponse.result.variants.find((v) =>
+      v.endsWith(variant)
+    )
+    if (!variantUrl) {
+      throw new Error(`No URL found for variant: ${variant}`)
+    }
+    return variantUrl
+  }
+
+  const formElement = event.currentTarget
+  const filteredFileInputs = getFilteredFileInputs(formElement)
+
+  const imgUploadUrl = await getUploadUrl()
+  const fileUrls = await Promise.all(
+    filteredFileInputs.map(async ({ file, variant, name }) => {
+      const uploadResponse = await uploadFile(file, imgUploadUrl)
+      return {
+        name,
+        url: extractVariantUrl(uploadResponse, variant!),
+      }
+    })
+  )
+
+  return fileUrls
+}

--- a/apps/profile/server.ts
+++ b/apps/profile/server.ts
@@ -15,6 +15,7 @@ declare module '@remix-run/server-runtime' {
   interface AppLoadContext {
     traceSpan: TraceSpan
     env: Env
+    waitUntil: (promise: Promise<any>) => void
   }
 }
 
@@ -44,6 +45,7 @@ const handleEvent = async (event: FetchEvent, env: Env) => {
         return {
           traceSpan,
           env,
+          waitUntil: event.waitUntil,
         }
       },
     })

--- a/platform/images/src/jsonrpc/methods/delete.ts
+++ b/platform/images/src/jsonrpc/methods/delete.ts
@@ -19,11 +19,11 @@ export const deleteMethod = async ({
   const imageComponents = input.split('/')
   const imageID = imageComponents[imageComponents.length - 2]
 
-  const url = `https://api.cloudflare.com/client/v4/accounts/${ctx.INTERNAL_CLOUDFLARE_ACCOUNT_ID}/images/v1/${imageID}`
+  const url = `https://api.cloudflare.com/client/v4/accounts/${ctx.env.INTERNAL_CLOUDFLARE_ACCOUNT_ID}/images/v1/${imageID}`
   const deleteRequest = new Request(url, {
     method: 'DELETE',
     headers: {
-      Authorization: `Bearer ${ctx.TOKEN_CLOUDFLARE_API}`,
+      Authorization: `Bearer ${ctx.env.TOKEN_CLOUDFLARE_API}`,
     },
   })
 

--- a/platform/images/src/jsonrpc/methods/delete.ts
+++ b/platform/images/src/jsonrpc/methods/delete.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+import { Context } from '../../context'
+
+export const DeleteMethodInputSchema = z.string()
+export type DeleteMethodInputParams = z.infer<typeof DeleteMethodInputSchema>
+
+export const DeleteMethodOutputSchema = z.boolean()
+export type DeleteMethodOutputParams = z.infer<typeof DeleteMethodOutputSchema>
+
+export const deleteMethod = async ({
+  input,
+  ctx,
+}: {
+  input: DeleteMethodInputParams
+  ctx: Context
+}): Promise<DeleteMethodOutputParams> => {
+  // A typical image delivery URL looks like this:
+  // https://imagedelivery.net/<ACCOUNT_HASH>/<IMAGE_ID>/<VARIANT_NAME>
+  const imageComponents = input.split('/')
+  const imageID = imageComponents[imageComponents.length - 2]
+
+  const url = `https://api.cloudflare.com/client/v4/accounts/${ctx.INTERNAL_CLOUDFLARE_ACCOUNT_ID}/images/v1/${imageID}`
+  const deleteRequest = new Request(url, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${ctx.TOKEN_CLOUDFLARE_API}`,
+    },
+  })
+
+  const response = await fetch(deleteRequest)
+  const res = (await response.json()) as {
+    success: boolean
+  }
+
+  return res.success
+}

--- a/platform/images/src/jsonrpc/router.ts
+++ b/platform/images/src/jsonrpc/router.ts
@@ -21,6 +21,11 @@ import {
 } from './methods/getGradient'
 
 import { Context } from '../context'
+import {
+  DeleteMethodInputSchema,
+  DeleteMethodOutputSchema,
+  deleteMethod,
+} from './methods/delete'
 
 const t = initTRPC.context<Context>().create({ errorFormatter })
 
@@ -31,6 +36,12 @@ export const appRouter = t.router({
     .input(uploadMethodInput)
     .output(uploadMethodOutput)
     .mutation(uploadMethod),
+  delete: t.procedure
+    .use(LogUsage)
+    .use(Analytics)
+    .input(DeleteMethodInputSchema)
+    .output(DeleteMethodOutputSchema)
+    .mutation(deleteMethod),
   getOgImage: t.procedure
     .use(LogUsage)
     .use(Analytics)


### PR DESCRIPTION
### Description

- [x] Added delete endpoint to the image worker
- [x] Added 'change' checks to existing image url properties
- [x] Call delete endpoint after update (so it doesn't interfere with the actual updating)

### Related Issues

- Closes #2549 

### Testing

- Visual check in CF image bucket

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
