### PR TITLE
chore(console): Onboarding flow for teams

### DIFF
--- a/apps/console/app/routes/groups.enroll.$groupID.$invitationCode.tsx
+++ b/apps/console/app/routes/groups.enroll.$groupID.$invitationCode.tsx
@@ -159,7 +159,7 @@ export const action: ActionFunction = getRollupReqFunctionErrorWrapper(
       identityGroupURN,
     })
 
-    return redirect(`/groups/${groupID}`)
+    return redirect(`/onboarding`)
   }
 )
 

--- a/apps/console/app/routes/onboarding.tsx
+++ b/apps/console/app/routes/onboarding.tsx
@@ -56,10 +56,11 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
 
     const igs = await coreClient.identity.listIdentityGroups.query()
     const targetIG =
-      (igs[0] &&
-        igs[0].members.length > 1 &&
-        igs[0].members[0].URN !== identityURN) ??
-      undefined
+      igs[0] &&
+      igs[0].members.length > 1 &&
+      igs[0].members[0].URN !== identityURN
+        ? igs[0]
+        : undefined
 
     return json({
       url: request.url,

--- a/apps/console/app/routes/onboarding/index.tsx
+++ b/apps/console/app/routes/onboarding/index.tsx
@@ -16,11 +16,7 @@ import { Input } from '@proofzero/design-system/src/atoms/form/Input'
 import { DocumentationBadge } from '~/components/DocumentationBadge'
 import { requireJWT } from '~/utilities/session.server'
 import { BadRequestError, InternalServerError } from '@proofzero/errors'
-import {
-  json,
-  type ActionFunction,
-  LoaderFunction,
-} from '@remix-run/cloudflare'
+import { json, type ActionFunction } from '@remix-run/cloudflare'
 import { getRollupReqFunctionErrorWrapper } from '@proofzero/utils/errors'
 import createCoreClient from '@proofzero/platform-clients/core'
 import { getAuthzHeaderConditionallyFromToken } from '@proofzero/utils'

--- a/platform/identity/src/jsonrpc/methods/identity-groups/createIdentityGroup.ts
+++ b/platform/identity/src/jsonrpc/methods/identity-groups/createIdentityGroup.ts
@@ -13,8 +13,12 @@ import { createAnalyticsEvent } from '@proofzero/utils/analytics'
 export const CreateIdentityGroupInputSchema = z.object({
   name: z.string(),
 })
-
 type CreateIdentityGroupInput = z.infer<typeof CreateIdentityGroupInputSchema>
+
+export const CreateIdentityGroupOutputSchema = z.object({
+  groupID: z.string(),
+})
+type CreateIdentityGroupOutput = z.infer<typeof CreateIdentityGroupOutputSchema>
 
 export const createIdentityGroup = async ({
   input,
@@ -22,7 +26,7 @@ export const createIdentityGroup = async ({
 }: {
   input: CreateIdentityGroupInput
   ctx: Context
-}): Promise<void> => {
+}): Promise<CreateIdentityGroupOutput> => {
   const name = hexlify(randomBytes(IDENTITY_GROUP_OPTIONS.length))
   const groupURN = IdentityGroupURNSpace.componentizedUrn(name, undefined, {
     name: input.name,
@@ -69,4 +73,8 @@ export const createIdentityGroup = async ({
       },
     })
   )
+
+  return {
+    groupID: name,
+  }
 }

--- a/platform/identity/src/jsonrpc/router.ts
+++ b/platform/identity/src/jsonrpc/router.ts
@@ -49,6 +49,7 @@ import {
 import { UnauthorizedError } from '@proofzero/errors'
 import {
   CreateIdentityGroupInputSchema,
+  CreateIdentityGroupOutputSchema,
   createIdentityGroup,
 } from './methods/identity-groups/createIdentityGroup'
 import {
@@ -194,6 +195,7 @@ export const appRouter = t.router({
     .use(LogUsage)
     .use(Analytics)
     .input(CreateIdentityGroupInputSchema)
+    .output(CreateIdentityGroupOutputSchema)
     .mutation(createIdentityGroup),
   listIdentityGroups: t.procedure
     .use(AuthorizationTokenFromHeader)


### PR DESCRIPTION
### Description

- Enabled group (team) creation flow;
- Added a new group (team) enrollment flow;

These two additions build on what was already existing in the onboarding flow with minimal possible changes. Currently there are some code smells that might prove problematic in the future but these belong to another PR.

- Enrollment now redirects to onboarding instead of group;
- Onboarding can be skipped after filling in billing details.

### Related Issues

- Closes #2645 

### Testing

#### Basic onboarding
1. Go to console
2. Get redirected to passport
3. Connect using a new account
4. Select single dev
5. Fill in app details
6. Continue to app

#### Team onboarding
1. Go to console
2. Get redirected to passport
3. Connect using a new accont
4. Select team
5. Fill in group name & other form items
7. Continue to group

#### Team enrollment onboarding
1. In the previously created group invite a new member
2. As the new member go to invitation link
3. Connect your account and accept invitation
4. Get redirected to onboarding
5. Group name is readonly
6. Fill in team role
7. Continue to group

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
