### PR TITLE
fix(passport): test email login

### DIFF
--- a/apps/passport/app/routes/connect/email/otp.ts
+++ b/apps/passport/app/routes/connect/email/otp.ts
@@ -80,7 +80,8 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
       // the localhost url is sent without a protocol
       // and trpc fails validation for proper url
       let passportURL = new URL(request.url).host
-      if (passportURL.includes('localhost')) {
+      let hostWithoutPort = passportURL.split(':')[0]
+      if (hostWithoutPort === 'localhost') {
         passportURL = `http://${passportURL}`
       }
 

--- a/apps/passport/app/routes/connect/email/otp.ts
+++ b/apps/passport/app/routes/connect/email/otp.ts
@@ -76,6 +76,9 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
         }
       }
 
+      // When making requests from localhost to the e-mail otp endpoint,
+      // the localhost url is sent without a protocol
+      // and trpc fails validation for proper url
       let passportURL = new URL(request.url).host
       if (passportURL.includes('localhost')) {
         passportURL = `http://${passportURL}`

--- a/apps/passport/app/routes/connect/email/otp.ts
+++ b/apps/passport/app/routes/connect/email/otp.ts
@@ -76,8 +76,13 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
         }
       }
 
+      let passportURL = new URL(request.url).host
+      if (passportURL.includes('localhost')) {
+        passportURL = `http://${passportURL}`
+      }
+
       const state = await coreClient.account.generateEmailOTP.mutate({
-        passportURL: new URL(request.url).host,
+        passportURL,
         clientId,
         email,
         themeProps,


### PR DESCRIPTION
### Description

When making requests from localhost to the e-mail otp endpoint, the localhost url is sent without a protocol and trpc fails validation for proper url. So this should fix that.

### Testing

<img width="1001" alt="image" src="https://github.com/proofzero/rollupid/assets/635806/6342b585-19f4-4ef4-ba32-2d1767bc9bb5">

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
