### PR TITLE
fix(passport): get `origin` property from the request URL

### DIFF
--- a/apps/passport/app/routes/connect/email/otp.ts
+++ b/apps/passport/app/routes/connect/email/otp.ts
@@ -77,7 +77,7 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
       }
 
       const state = await coreClient.account.generateEmailOTP.mutate({
-        passportURL: new URL(request.url).host,
+        passportURL: new URL(request.url).origin,
         clientId,
         email,
         themeProps,


### PR DESCRIPTION
### Description

The [`origin`](https://developer.mozilla.org/en-US/docs/Web/API/URL/origin) property is the one that has all components to construct a proper URL.

### Testing

- [x] Manual

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [x] I have updated the documentation (if necessary)