### PR TITLE
fix(passport): Group invite authentication page missing inviter&invitee

### DIFF
--- a/apps/passport/app/routes/authenticate/$clientId/index.tsx
+++ b/apps/passport/app/routes/authenticate/$clientId/index.tsx
@@ -74,7 +74,7 @@ export const loader: LoaderFunction = getRollupReqFunctionErrorWrapper(
     )
 
     let invitationData
-    if (authzParams.rollup_action?.startsWith('groupconnect')) {
+    if (authzParams.rollup_action?.startsWith('group_')) {
       const groupID = authzParams.rollup_action.split('_')[1]
       const invitationCode = authzParams.rollup_action.split('_')[2]
 
@@ -265,7 +265,7 @@ const InnerComponent = ({
                 has invited you to join group
                 <br />
                 <Text type="span" className="truncate" weight="bold">
-                  "{invitationData.groupName}""
+                  "{invitationData.groupName}"
                 </Text>
               </Text>
               <Text className="truncate max-w-xs">


### PR DESCRIPTION
### Description

### Related Issues

- Closes #2765 

### Testing

- Went through the invite flow and saw the screen;
- Went through the connect group email flow to make sure that still works.

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
