### PR TITLE
fix(persona): check if requested scopes include `email`

### DIFF
--- a/packages/security/persona.ts
+++ b/packages/security/persona.ts
@@ -241,6 +241,7 @@ export type ClaimData = {
 }
 
 export type ScopeClaimRetrieverFunction = (
+  scope: string[],
   scopeEntry: ScopeValueName,
   identityURN: IdentityURN,
   clientId: string,
@@ -285,6 +286,7 @@ class InvalidPersonaDataError extends RollupError {
 
 //These retriever functions will be moved elsewhere as part of ticket #2013
 async function emailClaimRetriever(
+  scope: string[],
   scopeEntry: ScopeValueName,
   identityURN: IdentityURN,
   clientId: string,
@@ -344,6 +346,7 @@ async function emailClaimRetriever(
 }
 
 async function profileClaimsRetriever(
+  scope: string[],
   scopeEntry: ScopeValueName,
   identityURN: IdentityURN,
   clientId: string,
@@ -376,6 +379,7 @@ async function profileClaimsRetriever(
 }
 
 async function erc4337ClaimsRetriever(
+  scope: string[],
   scopeEntry: ScopeValueName,
   identityURN: IdentityURN,
   clientId: string,
@@ -447,6 +451,7 @@ type ConnectedAccount = {
 }
 
 async function connectedAccountsClaimsRetriever(
+  scope: string[],
   scopeEntry: ScopeValueName,
   identityURN: IdentityURN,
   clientId: string,
@@ -584,6 +589,7 @@ export async function getClaimValues(
     if (!retrieverFunction) return
     else
       return retrieverFunction(
+        scope,
         scopeValue,
         identityURN,
         clientId,

--- a/packages/security/persona.ts
+++ b/packages/security/persona.ts
@@ -489,7 +489,7 @@ async function connectedAccountsClaimsRetriever(
       ({ rc: { addr_type } }) => addr_type !== CryptoAccountType.Wallet
     )
 
-    if (personaData.email) {
+    if (scope.includes('email') && personaData.email) {
       const [emailProfile] =
         await coreClient.account.getAccountProfileBatch.query([
           personaData.email,


### PR DESCRIPTION
The authorization scope is passed to the retriever functions to implement
inter-scope dependent requirements.

### Related Issues

- Closes #2783

### Testing

- [x] Manual

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [x] I have updated the documentation (if necessary)