### PR TITLE
fix(email): Remove 'the' from some transactional emails

### DIFF
--- a/platform/email/emailTemplate.ts
+++ b/platform/email/emailTemplate.ts
@@ -370,7 +370,7 @@ export const EmailTemplateFailedPayment = (
   const content = `<div class="heading">Payment Issue Detected</div>
 
   <p>
-    Your payment for the Rollup ID has failed.
+    Your payment for Rollup ID has failed.
   </p>
 
   <p>
@@ -398,7 +398,7 @@ export const EmailTemplateSuccessfulPayment = ({
 }): EmailContent => {
   const content = `<div class="heading">Payment Successful</div>
   <p>
-    Your payment for the <b>Rollup ID</b> has been processed successfully.
+    Your payment for <b>Rollup ID</b> has been processed successfully.
   </p>
 
   <p>


### PR DESCRIPTION
### Description

Two transactional emails -- purchase successful and purchase failure -- referred to "the Rollup ID". This removes the article "the" so that branding is more consistent.

### Related Issues

- NA

### Testing

NA

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [na] I have tested my code (manually and/or automated if applicable)
- [na] I have updated the documentation (if necessary)
