### PR TITLE
chore(galaxy): Operation for retrieving authorized identities

### DIFF
--- a/platform/galaxy/src/index.ts
+++ b/platform/galaxy/src/index.ts
@@ -25,7 +25,7 @@ const plugins = [
         galaxyApiKey: {
           type: 'apiKey',
           in: 'header',
-          name: 'X-GALAXY-API-KEY',
+          name: 'X-GALAXY-KEY',
           description: 'Galaxy API Key',
         },
         bearerAuthorization: {

--- a/platform/galaxy/src/schema/resolvers/authorization.ts
+++ b/platform/galaxy/src/schema/resolvers/authorization.ts
@@ -12,6 +12,13 @@ import { ResolverContext } from './common'
 import createCoreClient from '@proofzero/platform-clients/core'
 import { getAuthzHeaderConditionallyFromToken } from '@proofzero/utils'
 import { generateTraceContextHeaders } from '@proofzero/platform-middleware/trace'
+import { GraphQLError } from 'graphql/error'
+import { AppAPIKeyHeader } from '@proofzero/types/headers'
+import {
+  ApplicationURN,
+  ApplicationURNSpace,
+} from '@proofzero/urns/application'
+import * as jose from 'jose'
 
 const authorizationResolvers: Resolvers = {
   Query: {
@@ -27,6 +34,53 @@ const authorizationResolvers: Resolvers = {
 
       return coreClient.authorization.getExternalAppData.query({
         clientId,
+      })
+    },
+    getAuthorizedIdentities: async (
+      _parent: any,
+      { opts }: { opts: { limit: number; offset: number } },
+      { env, apiKey, traceSpan }: ResolverContext
+    ) => {
+      const coreClient = createCoreClient(env.Core, {
+        ...generateTraceContextHeaders(traceSpan),
+        [AppAPIKeyHeader]: apiKey,
+      })
+      const { limit, offset } = opts
+
+      //Check if valid numbers, including value of 0 for offset
+      if (
+        limit == null ||
+        offset == null ||
+        !Number.isInteger(limit) ||
+        !Number.isInteger(offset) ||
+        limit > 50 ||
+        limit < 1
+      )
+        throw new GraphQLError(
+          'Limit and offset numbers need to be provided, with the limit beging between 1 and 50'
+        )
+
+      let clientIdFromApiKey
+      try {
+        const apiKeyApplicationURN = jose.decodeJwt(apiKey)
+          .sub as ApplicationURN
+        clientIdFromApiKey =
+          ApplicationURNSpace.nss(apiKeyApplicationURN).split('/')[1]
+      } catch (e) {
+        console.error('Error parsing clientId', e)
+        throw new GraphQLError('Could not retrieve clientId from API key.')
+      }
+
+      const edgeResults =
+        await coreClient.starbase.getAuthorizedIdentities.query({
+          client: clientIdFromApiKey,
+          opt: {
+            limit,
+            offset,
+          },
+        })
+      return edgeResults.identities.map(({ identityURN, imageURL, name }) => {
+        return { identityURN, imageURL, name }
       })
     },
   },
@@ -58,6 +112,12 @@ const AuthorizationResolverComposition = {
     validateJWTAndAPIKeyPresence(),
     validateApiKey(),
     isAuthorized(),
+    logAnalytics(),
+  ],
+  'Query.getAuthorizedIdentities': [
+    requestLogging(),
+    setupContext(),
+    validateApiKey(),
     logAnalytics(),
   ],
   'Mutation.setExternalAppData': [

--- a/platform/galaxy/src/schema/types/authorization.ts
+++ b/platform/galaxy/src/schema/types/authorization.ts
@@ -1,6 +1,13 @@
 export default /* GraphQL */ `
+  type AuthorizationIdentity {
+    identityURN: String
+    name: String
+    imageURL: String
+  }
+
   type Query {
     getExternalAppData: JSON
+    getAuthorizedIdentities(opts: Pagination!): [AuthorizationIdentity]
   }
 
   type Mutation {

--- a/platform/galaxy/src/schema/types/common.ts
+++ b/platform/galaxy/src/schema/types/common.ts
@@ -1,3 +1,8 @@
 export default /* GraphQL */ `
   scalar JSON
+
+  input Pagination {
+    offset: Int!
+    limit: Int!
+  }
 `

--- a/platform/starbase/src/jsonrpc/router.ts
+++ b/platform/starbase/src/jsonrpc/router.ts
@@ -212,6 +212,7 @@ export const appRouter = t.router({
   getAuthorizedIdentities: t.procedure
     .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
+    .use(ApiKeyExtractMiddleware)
     .use(LogUsage)
     .use(Analytics)
     .use(OwnAppsMiddleware)


### PR DESCRIPTION
### Description

Implements Galaxy operation to retrieve authorized identities for an application, identified through the API key.

Returns `identityURN`, `name` and `imageURL` for each entry.

Note: connected accounts won't be returned as those can be retrieved proactively on a per-user basis through the standard `/userinfo` endpoint, or reactively per-change-event through future work done under #2621

### Related Issues

- Closes #2716

### Testing

- Make graphql call to `getAuthorizedIdentities()` with a galaxy API key issued for an app with authorized users. 
- Validate same users appear as the ones in users listing in Console for same app

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
