### PR TITLE
fix(galaxy): Produces error when user listing resolver fails validation.

### DIFF
--- a/platform/galaxy/src/schema/resolvers/authorization.ts
+++ b/platform/galaxy/src/schema/resolvers/authorization.ts
@@ -19,6 +19,7 @@ import {
   ApplicationURNSpace,
 } from '@proofzero/urns/application'
 import * as jose from 'jose'
+import { BadRequestError } from '@proofzero/errors'
 
 const authorizationResolvers: Resolvers = {
   Query: {
@@ -56,9 +57,10 @@ const authorizationResolvers: Resolvers = {
         limit > 50 ||
         limit < 1
       )
-        throw new GraphQLError(
-          'Limit and offset numbers need to be provided, with the limit beging between 1 and 50'
-        )
+        throw new BadRequestError({
+          message:
+            'Limit and offset numbers need to be provided, with the limit beging between 1 and 50',
+        })
 
       let clientIdFromApiKey
       try {
@@ -68,7 +70,9 @@ const authorizationResolvers: Resolvers = {
           ApplicationURNSpace.nss(apiKeyApplicationURN).split('/')[1]
       } catch (e) {
         console.error('Error parsing clientId', e)
-        throw new GraphQLError('Could not retrieve clientId from API key.')
+        throw new BadRequestError({
+          message: 'Could not retrieve clientId from API key.',
+        })
       }
 
       const edgeResults =


### PR DESCRIPTION
### Description

Resolver validation failures on `getAuthorizedIdentities` resolver now produce a user-visible error.

### Related Issues

- Closes #2833

### Testing

- Use a pagination input outside the valid range, eg. limit: 51

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
