### PR TITLE
fix(emailinbounder): Fixes email duplication in relay

### DIFF
--- a/packages/types/headers.ts
+++ b/packages/types/headers.ts
@@ -1,3 +1,5 @@
 export const PlatformAccountURNHeader = 'rollup-account-urn'
 
 export const AppAPIKeyHeader = 'APP-API-KEY'
+
+export const RelayRecipientHeader = 'X-rollup-relay-recipient'

--- a/platform/emaildistributor/src/index.ts
+++ b/platform/emaildistributor/src/index.ts
@@ -1,5 +1,6 @@
 import type { Environment } from './types'
 import type { CloudflareEmailMessage } from '@proofzero/packages/types/email'
+import { RelayRecipientHeader } from '@proofzero/types/headers'
 
 export default {
   async email(message: CloudflareEmailMessage, env: Environment) {
@@ -31,7 +32,9 @@ export default {
       console.info(
         `Forwarding to env suffix ${addressEnvSuffix} for ${message.to}`
       )
-      await message.forward(targetEnvEmail)
+      const newHeaders = new Headers(message.headers)
+      newHeaders.append(RelayRecipientHeader, message.to)
+      await message.forward(targetEnvEmail, newHeaders)
     }
   },
 }

--- a/platform/emailinbounder/.dev.vars.example
+++ b/platform/emailinbounder/.dev.vars.example
@@ -2,4 +2,3 @@
 #JSON object containing mapping between env specific identifier in the email address
 #and the target internal (hence, secret) email to be forwarded to for env-specific processor
 SECRET_RELAY_DISTRIBUTION_MAP="{'local':'supersecretemail@example.com'}"
-INTERNAL_RELAY_DISTRIBUTION_KEY = "local"

--- a/platform/emailinbounder/wrangler.current.toml
+++ b/platform/emailinbounder/wrangler.current.toml
@@ -15,3 +15,4 @@ services = [{ binding = "Core", service = "core-current" }]
 [env.current.vars]
 INTERNAL_RELAY_DKIM_DOMAIN = "rollup.email"
 INTERNAL_RELAY_DKIM_SELECTOR = "mailchannels"
+INTERNAL_EMAIL_DISTRIBUTION_KEY = "id"

--- a/platform/emailinbounder/wrangler.dev.toml
+++ b/platform/emailinbounder/wrangler.dev.toml
@@ -15,3 +15,4 @@ services = [{ binding = "Core", service = "core-dev" }]
 [env.dev.vars]
 INTERNAL_RELAY_DKIM_DOMAIN = "rollup.email"
 INTERNAL_RELAY_DKIM_SELECTOR = "mailchannels"
+INTERNAL_EMAIL_DISTRIBUTION_KEY = "dev"

--- a/platform/emailinbounder/wrangler.next.toml
+++ b/platform/emailinbounder/wrangler.next.toml
@@ -15,3 +15,4 @@ services = [{ binding = "Core", service = "core-next" }]
 [env.next.vars]
 INTERNAL_RELAY_DKIM_DOMAIN = "rollup.email"
 INTERNAL_RELAY_DKIM_SELECTOR = "mailchannels"
+INTERNAL_EMAIL_DISTRIBUTION_KEY = "next"

--- a/platform/emailinbounder/wrangler.toml
+++ b/platform/emailinbounder/wrangler.toml
@@ -15,3 +15,4 @@ local_protocol = "http"
 [vars]
 INTERNAL_RELAY_DKIM_DOMAIN = "rollup.email"
 INTERNAL_RELAY_DKIM_SELECTOR = "mailchannels"
+INTERNAL_EMAIL_DISTRIBUTION_KEY = "local"


### PR DESCRIPTION
### Description

Prevents duplicate relay emails from being sent, when there are multiple relay addresses in to/cc fields.

Also moves env var from being considered a secret to a regular env var.

### Related Issues

- Closes #2840

### Testing

Send email to at least 2 relay addresses and ensure only one copy is received on each target unmasked address. 

### Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] I have tested my code (manually and/or automated if applicable)
- [ ] I have updated the documentation (if necessary)
